### PR TITLE
annotate destination buffers with OutAttribute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
 

--- a/GenerateBindings/Program.cs
+++ b/GenerateBindings/Program.cs
@@ -418,6 +418,9 @@ internal static partial class Program
                                 case UserProvidedData.PointerParameterIntent.Array:
 									typeName = CoreMode ? $"Span<{subtypeName}>" : $"{subtypeName}[]";
                                     break;
+                                case UserProvidedData.PointerParameterIntent.OutArray:
+									typeName = CoreMode ? $"Span<{subtypeName}>" : $"[Out] {subtypeName}[]";
+                                    break;
                                 case UserProvidedData.PointerParameterIntent.Pointer:
 									typeName = CoreMode ? $"Span<{subtypeName}>" : $"{subtypeName}*";
                                     break;

--- a/GenerateBindings/UserProvidedData.cs
+++ b/GenerateBindings/UserProvidedData.cs
@@ -9,6 +9,7 @@ internal static class UserProvidedData
         Ref,
         Out,
         Array,
+        OutArray,
         Pointer,
         In,
     }
@@ -339,7 +340,7 @@ internal static class UserProvidedData
         { ("SDL_CreateColorCursor", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:460:42
         { ("SDL_GetTouchDevices", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:93:43
         { ("SDL_GetTouchFingers", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:129:43
-        { ("SDL_PeepEvents", "events"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_events.h:1047:33
+        { ("SDL_PeepEvents", "events"), PointerParameterIntent.OutArray }, // /usr/local/include/SDL3/SDL_events.h:1047:33
         { ("SDL_PollEvent", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1178:34
         { ("SDL_WaitEvent", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1200:34
         { ("SDL_WaitEventTimeout", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1228:34

--- a/SDL3/SDL3.Legacy.cs
+++ b/SDL3/SDL3.Legacy.cs
@@ -4886,7 +4886,7 @@ namespace SDL3
 		}
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int SDL_PeepEvents(SDL_Event[] events, int numevents, SDL_EventAction action, uint minType, uint maxType);
+		public static extern int SDL_PeepEvents([Out] SDL_Event[] events, int numevents, SDL_EventAction action, uint minType, uint maxType);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDLBool SDL_HasEvent(uint type);


### PR DESCRIPTION
updated the generator as per https://github.com/flibitijibibo/SDL3-CS/pull/22

i did a quick audit of the other parameters currently annotated with the Array intent, and judging from the header file documentation, `SDL_PeepEvents` has the only Array parameter intended as a destination buffer.