### PR TITLE
omit inlined functions from bindings

### DIFF
--- a/GenerateBindings/UserProvidedData.cs
+++ b/GenerateBindings/UserProvidedData.cs
@@ -117,13 +117,6 @@ internal static class UserProvidedData
         { ("SDL_GetRGBA", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
         { ("SDL_GetRGBA", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
         { ("SDL_GetRGBA", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_RectToFRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:126:23
-        { ("SDL_RectToFRect", "frect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:126:23
-        { ("SDL_PointInRect", "p"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:155:23
-        { ("SDL_PointInRect", "r"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:155:23
-        { ("SDL_RectEmpty", "r"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:179:23
-        { ("SDL_RectsEqual", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:203:23
-        { ("SDL_RectsEqual", "b"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:203:23
         { ("SDL_HasRectIntersection", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
         { ("SDL_HasRectIntersection", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
         { ("SDL_GetRectIntersection", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:241:34
@@ -140,13 +133,6 @@ internal static class UserProvidedData
         { ("SDL_GetRectAndLineIntersection", "Y1"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
         { ("SDL_GetRectAndLineIntersection", "X2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
         { ("SDL_GetRectAndLineIntersection", "Y2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_PointInRectFloat", "p"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:320:23
-        { ("SDL_PointInRectFloat", "r"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:320:23
-        { ("SDL_RectEmptyFloat", "r"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:344:23
-        { ("SDL_RectsEqualEpsilon", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:374:23
-        { ("SDL_RectsEqualEpsilon", "b"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:374:23
-        { ("SDL_RectsEqualFloat", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:409:23
-        { ("SDL_RectsEqualFloat", "b"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:409:23
         { ("SDL_HasRectIntersectionFloat", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
         { ("SDL_HasRectIntersectionFloat", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
         { ("SDL_GetRectIntersectionFloat", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:444:34

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -212,10 +212,6 @@ public static unsafe partial class SDL
 
 	// /usr/local/include/SDL3/SDL_endian.h
 
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial float SDL_SwapFloat(float x);
-
 	// /usr/local/include/SDL3/SDL_error.h
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
@@ -1004,14 +1000,6 @@ public static unsafe partial class SDL
 
 	// /usr/local/include/SDL3/SDL_bits.h
 
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial int SDL_MostSignificantBitIndex32(uint x);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_HasExactlyOneBitSet32(uint x);
-
 	// /usr/local/include/SDL3/SDL_blendmode.h
 
 	public enum SDL_BlendOperation
@@ -1408,22 +1396,6 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_RectToFRect(ref SDL_Rect rect, out SDL_FRect frect);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_PointInRect(ref SDL_Point p, ref SDL_Rect r);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RectEmpty(ref SDL_Rect r);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RectsEqual(ref SDL_Rect a, ref SDL_Rect b);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_HasRectIntersection(ref SDL_Rect A, ref SDL_Rect B);
 
 	[LibraryImport(nativeLibName)]
@@ -1441,22 +1413,6 @@ public static unsafe partial class SDL
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_GetRectAndLineIntersection(ref SDL_Rect rect, ref int X1, ref int Y1, ref int X2, ref int Y2);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_PointInRectFloat(ref SDL_FPoint p, ref SDL_FRect r);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RectEmptyFloat(ref SDL_FRect r);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RectsEqualEpsilon(ref SDL_FRect a, ref SDL_FRect b, float epsilon);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RectsEqualFloat(ref SDL_FRect a, ref SDL_FRect b);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -8068,10 +8024,6 @@ public static unsafe partial class SDL
 
 	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate int SDL_main_func(int argc, IntPtr argv);
-
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial int SDL_main(int argc, IntPtr argv);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3/SDL3.Legacy.cs
+++ b/SDL3/SDL3.Legacy.cs
@@ -229,9 +229,6 @@ namespace SDL3
 
 		// /usr/local/include/SDL3/SDL_endian.h
 
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern float SDL_SwapFloat(float x);
-
 		// /usr/local/include/SDL3/SDL_error.h
 
 		[DllImport(nativeLibName, EntryPoint = "SDL_SetError", CallingConvention = CallingConvention.Cdecl)]
@@ -1041,12 +1038,6 @@ namespace SDL3
 
 		// /usr/local/include/SDL3/SDL_bits.h
 
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int SDL_MostSignificantBitIndex32(uint x);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_HasExactlyOneBitSet32(uint x);
-
 		// /usr/local/include/SDL3/SDL_blendmode.h
 
 		public enum SDL_BlendOperation
@@ -1433,18 +1424,6 @@ namespace SDL3
 		}
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void SDL_RectToFRect(ref SDL_Rect rect, out SDL_FRect frect);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_PointInRect(ref SDL_Point p, ref SDL_Rect r);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_RectEmpty(ref SDL_Rect r);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_RectsEqual(ref SDL_Rect a, ref SDL_Rect b);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDLBool SDL_HasRectIntersection(ref SDL_Rect A, ref SDL_Rect B);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
@@ -1458,18 +1437,6 @@ namespace SDL3
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDLBool SDL_GetRectAndLineIntersection(ref SDL_Rect rect, ref int X1, ref int Y1, ref int X2, ref int Y2);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_PointInRectFloat(ref SDL_FPoint p, ref SDL_FRect r);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_RectEmptyFloat(ref SDL_FRect r);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_RectsEqualEpsilon(ref SDL_FRect a, ref SDL_FRect b, float epsilon);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern SDLBool SDL_RectsEqualFloat(ref SDL_FRect a, ref SDL_FRect b);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern SDLBool SDL_HasRectIntersectionFloat(ref SDL_FRect A, ref SDL_FRect B);
@@ -8131,9 +8098,6 @@ namespace SDL3
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		public delegate int SDL_main_func(int argc, IntPtr argv);
-
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern int SDL_main(int argc, IntPtr argv);
 
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern void SDL_SetMainReady();


### PR DESCRIPTION
resolves https://github.com/flibitijibibo/SDL3-CS/issues/24

unfortunately compiler extensions are not represented in the FFI output. so this PR runs a regex against the corresponding header file for the relevant macros (`SDL_FORCE_INLINE` and `SDLMAIN_DECLSPEC`), records the function names, and omits them from the generation.

also took the opportunity to consolidate the various header file regex operations into one pass per file.