### PR TITLE
specify return types where possible

### DIFF
--- a/GenerateBindings/UserProvidedData.cs
+++ b/GenerateBindings/UserProvidedData.cs
@@ -2,7 +2,7 @@ namespace GenerateBindings;
 
 internal static class UserProvidedData
 {
-    internal enum PointerParameterIntent
+    internal enum PointerFunctionDataIntent
     {
         Unknown,
         IntPtr,
@@ -27,494 +27,531 @@ internal static class UserProvidedData
         public (string, string)[] Parameters { get; set; }
     }
 
-    internal static readonly Dictionary<(string, string), PointerParameterIntent> PointerParametersIntents = new()
+    internal static readonly Dictionary<(string, string), PointerFunctionDataIntent> PointerFunctionDataIntents = new()
     {
-        { ("SDL_ReportAssertion", "data"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_assert.h:245:45
-        { ("SDL_GetAssertionHandler", "puserdata"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_assert.h:489:50
-        { ("SDL_CompareAndSwapAtomicInt", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:348:34
-        { ("SDL_SetAtomicInt", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:368:33
-        { ("SDL_GetAtomicInt", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:385:33
-        { ("SDL_AddAtomicInt", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:406:33
-        { ("SDL_CompareAndSwapAtomicU32", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:490:34
-        { ("SDL_SetAtomicU32", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:510:36
-        { ("SDL_GetAtomicU32", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:527:36
-        { ("SDL_CompareAndSwapAtomicPointer", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:548:34
-        { ("SDL_SetAtomicPointer", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:567:36
-        { ("SDL_GetAtomicPointer", "a"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:585:36
-        { ("SDL_WaitThread", "status"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_thread.h:423:34
-        { ("SDL_ShouldInit", "state"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:864:34
-        { ("SDL_ShouldQuit", "state"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:885:34
-        { ("SDL_SetInitialized", "state"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:904:34
-        { ("SDL_OpenIO", "iface"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_iostream.h:402:44
-        { ("SDL_LoadFile_IO", "datasize"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:651:36
-        { ("SDL_LoadFile", "datasize"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:671:36
-        { ("SDL_ReadU8", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:690:34
-        { ("SDL_ReadS8", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:702:34
-        { ("SDL_ReadU16LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:718:34
-        { ("SDL_ReadS16LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:734:34
-        { ("SDL_ReadU16BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:750:34
-        { ("SDL_ReadS16BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:766:34
-        { ("SDL_ReadU32LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:782:34
-        { ("SDL_ReadS32LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:798:34
-        { ("SDL_ReadU32BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:814:34
-        { ("SDL_ReadS32BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:830:34
-        { ("SDL_ReadU64LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:846:34
-        { ("SDL_ReadS64LE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:862:34
-        { ("SDL_ReadU64BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:878:34
-        { ("SDL_ReadS64BE", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:894:34
-        { ("SDL_GetAudioPlaybackDevices", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:461:49
-        { ("SDL_GetAudioRecordingDevices", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:490:49
-        { ("SDL_GetAudioDeviceFormat", "spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:542:34
-        { ("SDL_GetAudioDeviceFormat", "sample_frames"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:542:34
-        { ("SDL_GetAudioDeviceChannelMap", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:565:35
-        { ("SDL_OpenAudioDevice", "spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:641:47
-        { ("SDL_BindAudioStreams", "streams"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:838:34
-        { ("SDL_UnbindAudioStreams", "streams"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:879:34
-        { ("SDL_CreateAudioStream", "src_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:937:47
-        { ("SDL_CreateAudioStream", "dst_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:937:47
-        { ("SDL_GetAudioStreamFormat", "src_spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:966:34
-        { ("SDL_GetAudioStreamFormat", "dst_spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:966:34
-        { ("SDL_SetAudioStreamFormat", "src_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:997:34
-        { ("SDL_SetAudioStreamFormat", "dst_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:997:34
-        { ("SDL_GetAudioStreamInputChannelMap", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1111:35
-        { ("SDL_GetAudioStreamOutputChannelMap", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1135:35
-        { ("SDL_SetAudioStreamInputChannelMap", "chmap"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1186:34
-        { ("SDL_SetAudioStreamOutputChannelMap", "chmap"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1233:34
-        { ("SDL_OpenAudioDeviceStream", "spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1707:47
-        { ("SDL_LoadWAV_IO", "spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
-        { ("SDL_LoadWAV_IO", "audio_buf"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
-        { ("SDL_LoadWAV_IO", "audio_len"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
-        { ("SDL_LoadWAV", "spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
-        { ("SDL_LoadWAV", "audio_buf"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
-        { ("SDL_LoadWAV", "audio_len"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
-        { ("SDL_MixAudio", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1951:34
-        { ("SDL_MixAudio", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1951:34
-        { ("SDL_ConvertAudioSamples", "src_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
-        { ("SDL_ConvertAudioSamples", "src_data"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
-        { ("SDL_ConvertAudioSamples", "dst_spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
-        { ("SDL_ConvertAudioSamples", "dst_data"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
-        { ("SDL_ConvertAudioSamples", "dst_len"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
-        { ("SDL_GetMasksForPixelFormat", "bpp"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
-        { ("SDL_GetMasksForPixelFormat", "Rmask"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
-        { ("SDL_GetMasksForPixelFormat", "Gmask"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
-        { ("SDL_GetMasksForPixelFormat", "Bmask"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
-        { ("SDL_GetMasksForPixelFormat", "Amask"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
-        { ("SDL_SetPaletteColors", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:863:34
-        { ("SDL_SetPaletteColors", "colors"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_pixels.h:863:34
-        { ("SDL_DestroyPalette", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:877:34
-        { ("SDL_MapRGB", "format"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:915:36
-        { ("SDL_MapRGB", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:915:36
-        { ("SDL_MapRGBA", "format"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:954:36
-        { ("SDL_MapRGBA", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:954:36
-        { ("SDL_GetRGB", "format"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
-        { ("SDL_GetRGB", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
-        { ("SDL_GetRGB", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
-        { ("SDL_GetRGB", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
-        { ("SDL_GetRGB", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
-        { ("SDL_GetRGBA", "format"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_GetRGBA", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_GetRGBA", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_GetRGBA", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_GetRGBA", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_GetRGBA", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
-        { ("SDL_HasRectIntersection", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
-        { ("SDL_HasRectIntersection", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
-        { ("SDL_GetRectIntersection", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:241:34
-        { ("SDL_GetRectIntersection", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:241:34
-        { ("SDL_GetRectIntersection", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:241:34
-        { ("SDL_GetRectUnion", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:255:34
-        { ("SDL_GetRectUnion", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:255:34
-        { ("SDL_GetRectUnion", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:255:34
-        { ("SDL_GetRectEnclosingPoints", "points"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_rect.h:274:34
-        { ("SDL_GetRectEnclosingPoints", "clip"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:274:34
-        { ("SDL_GetRectEnclosingPoints", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:274:34
-        { ("SDL_GetRectAndLineIntersection", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_GetRectAndLineIntersection", "X1"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_GetRectAndLineIntersection", "Y1"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_GetRectAndLineIntersection", "X2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_GetRectAndLineIntersection", "Y2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
-        { ("SDL_HasRectIntersectionFloat", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
-        { ("SDL_HasRectIntersectionFloat", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
-        { ("SDL_GetRectIntersectionFloat", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:444:34
-        { ("SDL_GetRectIntersectionFloat", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:444:34
-        { ("SDL_GetRectIntersectionFloat", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:444:34
-        { ("SDL_GetRectUnionFloat", "A"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:458:34
-        { ("SDL_GetRectUnionFloat", "B"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:458:34
-        { ("SDL_GetRectUnionFloat", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:458:34
-        { ("SDL_GetRectEnclosingPointsFloat", "points"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_rect.h:478:34
-        { ("SDL_GetRectEnclosingPointsFloat", "clip"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:478:34
-        { ("SDL_GetRectEnclosingPointsFloat", "result"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:478:34
-        { ("SDL_GetRectAndLineIntersectionFloat", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
-        { ("SDL_GetRectAndLineIntersectionFloat", "X1"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
-        { ("SDL_GetRectAndLineIntersectionFloat", "Y1"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
-        { ("SDL_GetRectAndLineIntersectionFloat", "X2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
-        { ("SDL_GetRectAndLineIntersectionFloat", "Y2"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
-        { ("SDL_DestroySurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:183:34
-        { ("SDL_GetSurfaceProperties", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:211:46
-        { ("SDL_SetSurfaceColorspace", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:233:34
-        { ("SDL_GetSurfaceColorspace", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:250:44
-        { ("SDL_CreateSurfacePalette", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:278:43
-        { ("SDL_SetSurfacePalette", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:295:34
-        { ("SDL_SetSurfacePalette", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:295:34
-        { ("SDL_GetSurfacePalette", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:308:43
-        { ("SDL_AddSurfaceAlternateImage", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:333:34
-        { ("SDL_AddSurfaceAlternateImage", "image"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:333:34
-        { ("SDL_SurfaceHasAlternateImages", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:347:34
-        { ("SDL_GetSurfaceImages", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:372:44
-        { ("SDL_GetSurfaceImages", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:372:44
-        { ("SDL_RemoveSurfaceAlternateImages", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:388:34
-        { ("SDL_LockSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:411:34
-        { ("SDL_UnlockSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:422:34
-        { ("SDL_SaveBMP_IO", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:483:34
-        { ("SDL_SaveBMP", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:504:34
-        { ("SDL_SetSurfaceRLE", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:523:34
-        { ("SDL_SurfaceHasRLE", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:537:34
-        { ("SDL_SetSurfaceColorKey", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:561:34
-        { ("SDL_SurfaceHasColorKey", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:576:34
-        { ("SDL_GetSurfaceColorKey", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:596:34
-        { ("SDL_GetSurfaceColorKey", "key"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:596:34
-        { ("SDL_SetSurfaceColorMod", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:619:34
-        { ("SDL_GetSurfaceColorMod", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:637:34
-        { ("SDL_GetSurfaceColorMod", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
-        { ("SDL_GetSurfaceColorMod", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
-        { ("SDL_GetSurfaceColorMod", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
-        { ("SDL_SetSurfaceAlphaMod", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:657:34
-        { ("SDL_GetSurfaceAlphaMod", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:672:34
-        { ("SDL_GetSurfaceAlphaMod", "alpha"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:672:34
-        { ("SDL_SetSurfaceBlendMode", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:690:34
-        { ("SDL_GetSurfaceBlendMode", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:704:34
-        { ("SDL_SetSurfaceClipRect", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:725:34
-        { ("SDL_SetSurfaceClipRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_surface.h:725:34
-        { ("SDL_GetSurfaceClipRect", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:744:34
-        { ("SDL_GetSurfaceClipRect", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:744:34
-        { ("SDL_FlipSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:756:34
-        { ("SDL_DuplicateSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:774:43
-        { ("SDL_ScaleSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:793:43
-        { ("SDL_ConvertSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:819:43
-        { ("SDL_ConvertSurfaceAndColorspace", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:846:43
-        { ("SDL_ConvertSurfaceAndColorspace", "palette"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:846:43
-        { ("SDL_PremultiplySurfaceAlpha", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:932:34
-        { ("SDL_ClearSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:952:34
-        { ("SDL_FillSurfaceRect", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:977:34
-        { ("SDL_FillSurfaceRect", "rect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:977:34
-        { ("SDL_FillSurfaceRects", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1002:34
-        { ("SDL_FillSurfaceRects", "rects"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_surface.h:1002:34
-        { ("SDL_BlitSurface", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
-        { ("SDL_BlitSurface", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
-        { ("SDL_BlitSurface", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
-        { ("SDL_BlitSurface", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
-        { ("SDL_BlitSurfaceUnchecked", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
-        { ("SDL_BlitSurfaceUnchecked", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
-        { ("SDL_BlitSurfaceUnchecked", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
-        { ("SDL_BlitSurfaceUnchecked", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
-        { ("SDL_BlitSurfaceScaled", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
-        { ("SDL_BlitSurfaceScaled", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
-        { ("SDL_BlitSurfaceScaled", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
-        { ("SDL_BlitSurfaceScaled", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
-        { ("SDL_BlitSurfaceUncheckedScaled", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
-        { ("SDL_BlitSurfaceUncheckedScaled", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
-        { ("SDL_BlitSurfaceUncheckedScaled", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
-        { ("SDL_BlitSurfaceUncheckedScaled", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
-        { ("SDL_BlitSurfaceTiled", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
-        { ("SDL_BlitSurfaceTiled", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
-        { ("SDL_BlitSurfaceTiled", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
-        { ("SDL_BlitSurfaceTiled", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
-        { ("SDL_BlitSurfaceTiledWithScale", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
-        { ("SDL_BlitSurfaceTiledWithScale", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
-        { ("SDL_BlitSurfaceTiledWithScale", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
-        { ("SDL_BlitSurfaceTiledWithScale", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
-        { ("SDL_BlitSurface9Grid", "src"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
-        { ("SDL_BlitSurface9Grid", "srcrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
-        { ("SDL_BlitSurface9Grid", "dst"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
-        { ("SDL_BlitSurface9Grid", "dstrect"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
-        { ("SDL_MapSurfaceRGB", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1276:36
-        { ("SDL_MapSurfaceRGBA", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1307:36
-        { ("SDL_ReadSurfacePixel", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
-        { ("SDL_ReadSurfacePixel", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
-        { ("SDL_ReadSurfacePixel", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
-        { ("SDL_ReadSurfacePixel", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
-        { ("SDL_ReadSurfacePixel", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
-        { ("SDL_ReadSurfacePixelFloat", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
-        { ("SDL_ReadSurfacePixelFloat", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
-        { ("SDL_ReadSurfacePixelFloat", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
-        { ("SDL_ReadSurfacePixelFloat", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
-        { ("SDL_ReadSurfacePixelFloat", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
-        { ("SDL_WriteSurfacePixel", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1381:34
-        { ("SDL_WriteSurfacePixelFloat", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1401:34
-        { ("SDL_GetCameras", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:183:44
-        { ("SDL_GetCameraSupportedFormats", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:222:47
-        { ("SDL_OpenCamera", "spec"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_camera.h:302:42
-        { ("SDL_GetCameraFormat", "spec"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:388:34
-        { ("SDL_AcquireCameraFrame", "timestampNS"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:431:43
-        { ("SDL_ReleaseCameraFrame", "frame"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_camera.h:459:34
-        { ("SDL_GetClipboardData", "size"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_clipboard.h:227:36
-        { ("SDL_GetClipboardMimeTypes", "num_mime_types"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_clipboard.h:256:37
-        { ("SDL_GetDisplays", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:415:45
-        { ("SDL_GetDisplayBounds", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:486:34
-        { ("SDL_GetDisplayUsableBounds", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:510:34
-        { ("SDL_GetFullscreenDisplayModes", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:580:48
-        { ("SDL_GetClosestFullscreenDisplayMode", "mode"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:609:34
-        { ("SDL_GetDisplayForPoint", "point"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:661:43
-        { ("SDL_GetDisplayForRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:676:43
-        { ("SDL_SetWindowFullscreenMode", "mode"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:763:34
-        { ("SDL_GetWindowICCProfile", "size"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:790:36
-        { ("SDL_GetWindows", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:816:43
-        { ("SDL_SetWindowIcon", "icon"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_video.h:1366:34
-        { ("SDL_GetWindowPosition", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1429:34
-        { ("SDL_GetWindowPosition", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1429:34
-        { ("SDL_GetWindowSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1486:34
-        { ("SDL_GetWindowSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1486:34
-        { ("SDL_GetWindowSafeArea", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1506:34
-        { ("SDL_GetWindowAspectRatio", "min_aspect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1562:34
-        { ("SDL_GetWindowAspectRatio", "max_aspect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1562:34
-        { ("SDL_GetWindowBordersSize", "top"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
-        { ("SDL_GetWindowBordersSize", "left"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
-        { ("SDL_GetWindowBordersSize", "bottom"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
-        { ("SDL_GetWindowBordersSize", "right"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
-        { ("SDL_GetWindowSizeInPixels", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1615:34
-        { ("SDL_GetWindowSizeInPixels", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1615:34
-        { ("SDL_GetWindowMinimumSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1649:34
-        { ("SDL_GetWindowMinimumSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1649:34
-        { ("SDL_GetWindowMaximumSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1683:34
-        { ("SDL_GetWindowMaximumSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1683:34
-        { ("SDL_GetWindowSurfaceVSync", "vsync"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2006:34
-        { ("SDL_UpdateWindowSurfaceRects", "rects"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_video.h:2052:34
-        { ("SDL_SetWindowMouseRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:2169:34
-        { ("SDL_SetWindowShape", "shape"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_video.h:2396:34
-        { ("SDL_GL_GetAttribute", "value"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2648:34
-        { ("SDL_GL_GetSwapInterval", "interval"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2813:34
-        { ("SDL_ShowOpenFileDialog", "filters"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_dialog.h:154:34
-        { ("SDL_ShowSaveFileDialog", "filters"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_dialog.h:209:34
-        { ("SDL_GetPowerInfo", "seconds"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_power.h:85:44
-        { ("SDL_GetPowerInfo", "percent"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_power.h:85:44
-        { ("SDL_GetSensors", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_sensor.h:151:44
-        { ("SDL_GetSensorData", "data"), PointerParameterIntent.Pointer }, // /usr/local/include/SDL3/SDL_sensor.h:280:34
-        { ("SDL_GetJoysticks", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:215:46
-        { ("SDL_AttachVirtualJoystick", "desc"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_joystick.h:482:44
-        { ("SDL_SendJoystickVirtualSensorData", "data"), PointerParameterIntent.Pointer }, // /usr/local/include/SDL3/SDL_joystick.h:635:34
-        { ("SDL_GetJoystickGUIDInfo", "vendor"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
-        { ("SDL_GetJoystickGUIDInfo", "product"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
-        { ("SDL_GetJoystickGUIDInfo", "version"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
-        { ("SDL_GetJoystickGUIDInfo", "crc16"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
-        { ("SDL_GetJoystickAxisInitialState", "state"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1013:34
-        { ("SDL_GetJoystickBall", "dx"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1034:34
-        { ("SDL_GetJoystickBall", "dy"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1034:34
-        { ("SDL_GetJoystickPowerInfo", "percent"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1200:44
-        { ("SDL_GetGamepadMappings", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:403:37
-        { ("SDL_GetGamepads", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:482:46
-        { ("SDL_GetGamepadPowerInfo", "percent"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:936:44
-        { ("SDL_GetGamepadBindings", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1011:51
-        { ("SDL_GetGamepadTouchpadFinger", "down"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
-        { ("SDL_GetGamepadTouchpadFinger", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
-        { ("SDL_GetGamepadTouchpadFinger", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
-        { ("SDL_GetGamepadTouchpadFinger", "pressure"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
-        { ("SDL_GetGamepadSensorData", "data"), PointerParameterIntent.Pointer }, // /usr/local/include/SDL3/SDL_gamepad.h:1340:34
-        { ("SDL_GetKeyboards", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:89:46
-        { ("SDL_GetKeyboardState", "numkeys"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:144:42
-        { ("SDL_SetTextInputArea", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_keyboard.h:499:34
-        { ("SDL_GetTextInputArea", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:518:34
-        { ("SDL_GetTextInputArea", "cursor"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:518:34
-        { ("SDL_GetMice", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:167:43
-        { ("SDL_GetMouseState", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:213:50
-        { ("SDL_GetMouseState", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:213:50
-        { ("SDL_GetGlobalMouseState", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:243:50
-        { ("SDL_GetGlobalMouseState", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:243:50
-        { ("SDL_GetRelativeMouseState", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:262:50
-        { ("SDL_GetRelativeMouseState", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:262:50
-        { ("SDL_CreateCursor", "data"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:429:42
-        { ("SDL_CreateCursor", "mask"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:429:42
-        { ("SDL_CreateColorCursor", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:460:42
-        { ("SDL_GetTouchDevices", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:93:43
-        { ("SDL_GetTouchFingers", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:129:43
-        { ("SDL_PeepEvents", "events"), PointerParameterIntent.OutArray }, // /usr/local/include/SDL3/SDL_events.h:1047:33
-        { ("SDL_PollEvent", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1178:34
-        { ("SDL_WaitEvent", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1200:34
-        { ("SDL_WaitEventTimeout", "event"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1228:34
-        { ("SDL_PushEvent", "event"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_events.h:1262:34
-        { ("SDL_GetEventFilter", "filter"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1348:34
-        { ("SDL_GetEventFilter", "userdata"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1348:34
-        { ("SDL_GetWindowFromEvent", "event"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_events.h:1465:42
-        { ("SDL_GetPathInfo", "info"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_filesystem.h:413:34
-        { ("SDL_GlobDirectory", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_filesystem.h:446:37
-        { ("SDL_CreateGPUComputePipeline", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1946:53
-        { ("SDL_CreateGPUGraphicsPipeline", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1965:54
-        { ("SDL_CreateGPUSampler", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1984:45
-        { ("SDL_CreateGPUShader", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2053:44
-        { ("SDL_CreateGPUTexture", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2088:45
-        { ("SDL_CreateGPUBuffer", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2122:44
-        { ("SDL_CreateGPUTransferBuffer", "createinfo"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2144:52
-        { ("SDL_BeginGPURenderPass", "color_target_infos"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2493:48
-        { ("SDL_BeginGPURenderPass", "depth_stencil_target_info"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2493:48
-        { ("SDL_SetGPUViewport", "viewport"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2521:34
-        { ("SDL_SetGPUScissor", "scissor"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2533:34
-        { ("SDL_BindGPUVertexBuffers", "bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2576:34
-        { ("SDL_BindGPUIndexBuffer", "binding"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2593:34
-        { ("SDL_BindGPUVertexSamplers", "texture_sampler_bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2612:34
-        { ("SDL_BindGPUVertexStorageTextures", "storage_textures"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2631:34
-        { ("SDL_BindGPUVertexStorageBuffers", "storage_buffers"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2650:34
-        { ("SDL_BindGPUFragmentSamplers", "texture_sampler_bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2670:34
-        { ("SDL_BindGPUFragmentStorageTextures", "storage_textures"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2689:34
-        { ("SDL_BindGPUFragmentStorageBuffers", "storage_buffers"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2708:34
-        { ("SDL_BeginGPUComputePass", "storage_texture_bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2866:49
-        { ("SDL_BeginGPUComputePass", "storage_buffer_bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2866:49
-        { ("SDL_BindGPUComputeSamplers", "texture_sampler_bindings"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2899:34
-        { ("SDL_BindGPUComputeStorageTextures", "storage_textures"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2918:34
-        { ("SDL_BindGPUComputeStorageBuffers", "storage_buffers"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2937:34
-        { ("SDL_UploadToGPUTexture", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3071:34
-        { ("SDL_UploadToGPUTexture", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3071:34
-        { ("SDL_UploadToGPUBuffer", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3093:34
-        { ("SDL_UploadToGPUBuffer", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3093:34
-        { ("SDL_CopyGPUTextureToTexture", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3116:34
-        { ("SDL_CopyGPUTextureToTexture", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3116:34
-        { ("SDL_CopyGPUBufferToBuffer", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3142:34
-        { ("SDL_CopyGPUBufferToBuffer", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3142:34
-        { ("SDL_DownloadFromGPUTexture", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3162:34
-        { ("SDL_DownloadFromGPUTexture", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3162:34
-        { ("SDL_DownloadFromGPUBuffer", "source"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3179:34
-        { ("SDL_DownloadFromGPUBuffer", "destination"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3179:34
-        { ("SDL_BlitGPUTexture", "info"), PointerParameterIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3218:34
-        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
-        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture_width"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
-        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture_height"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
-        { ("SDL_WaitForGPUFences", "fences"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:3466:34
-        { ("SDL_GetHaptics", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_haptic.h:943:44
-        { ("SDL_HapticEffectSupported", "effect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1167:34
-        { ("SDL_CreateHapticEffect", "effect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1184:33
-        { ("SDL_UpdateHapticEffect", "data"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1206:34
-        { ("SDL_hid_free_enumeration", "devs"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:252:34
-        { ("SDL_hid_write", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:311:33
-        { ("SDL_hid_read_timeout", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:332:33
-        { ("SDL_hid_read", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:353:33
-        { ("SDL_hid_send_feature_report", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:397:33
-        { ("SDL_hid_get_feature_report", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:420:33
-        { ("SDL_hid_get_input_report", "data"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:443:33
-        { ("SDL_hid_get_report_descriptor", "buf"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:535:33
-        { ("SDL_GetPreferredLocales", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_locale.h:101:43
-        { ("SDL_GetLogOutputFunction", "callback"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_log.h:490:34
-        { ("SDL_GetLogOutputFunction", "userdata"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_log.h:490:34
-        { ("SDL_ShowMessageBox", "messageboxdata"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_messagebox.h:164:34
-        { ("SDL_ShowMessageBox", "buttonid"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_messagebox.h:164:34
-        { ("SDL_ReadProcess", "datasize"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:283:36
-        { ("SDL_ReadProcess", "exitcode"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:283:36
-        { ("SDL_WaitProcess", "exitcode"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:383:34
-        { ("SDL_CreateWindowAndRenderer", "window"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:194:34
-        { ("SDL_CreateWindowAndRenderer", "renderer"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:194:34
-        { ("SDL_CreateSoftwareRenderer", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:312:44
-        { ("SDL_GetRenderOutputSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:479:34
-        { ("SDL_GetRenderOutputSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:479:34
-        { ("SDL_GetCurrentRenderOutputSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:501:34
-        { ("SDL_GetCurrentRenderOutputSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:501:34
-        { ("SDL_CreateTextureFromSurface", "surface"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:555:43
-        { ("SDL_GetTextureSize", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:848:34
-        { ("SDL_GetTextureSize", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:848:34
-        { ("SDL_GetTextureColorMod", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
-        { ("SDL_GetTextureColorMod", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
-        { ("SDL_GetTextureColorMod", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
-        { ("SDL_GetTextureColorModFloat", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
-        { ("SDL_GetTextureColorModFloat", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
-        { ("SDL_GetTextureColorModFloat", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
-        { ("SDL_GetTextureAlphaMod", "alpha"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1018:34
-        { ("SDL_GetTextureAlphaModFloat", "alpha"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1036:34
-        { ("SDL_GetTextureScaleMode", "scaleMode"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1107:34
-        { ("SDL_UpdateTexture", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1141:34
-        { ("SDL_UpdateYUVTexture", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1173:34
-        { ("SDL_UpdateYUVTexture", "Yplane"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
-        { ("SDL_UpdateYUVTexture", "Uplane"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
-        { ("SDL_UpdateYUVTexture", "Vplane"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
-        { ("SDL_UpdateNVTexture", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1205:34
-        { ("SDL_UpdateNVTexture", "Yplane"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1205:34
-        { ("SDL_UpdateNVTexture", "UVplane"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1205:34
-        { ("SDL_LockTexture", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1240:34
-        { ("SDL_LockTexture", "pixels"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1240:34
-        { ("SDL_LockTexture", "pitch"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1240:34
-        { ("SDL_LockTextureToSurface", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1278:34
-        { ("SDL_LockTextureToSurface", "surface"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1278:34
-        { ("SDL_GetRenderLogicalPresentation", "w"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
-        { ("SDL_GetRenderLogicalPresentation", "h"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
-        { ("SDL_GetRenderLogicalPresentation", "mode"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
-        { ("SDL_GetRenderLogicalPresentationRect", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1422:34
-        { ("SDL_RenderCoordinatesFromWindow", "x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1442:34
-        { ("SDL_RenderCoordinatesFromWindow", "y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1442:34
-        { ("SDL_RenderCoordinatesToWindow", "window_x"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1464:34
-        { ("SDL_RenderCoordinatesToWindow", "window_y"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1464:34
-        { ("SDL_ConvertEventToRenderCoordinates", "event"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1485:34
-        { ("SDL_SetRenderViewport", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1509:34
-        { ("SDL_GetRenderViewport", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1526:34
-        { ("SDL_GetRenderSafeArea", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1568:34
-        { ("SDL_SetRenderClipRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1586:34
-        { ("SDL_GetRenderClipRect", "rect"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1604:34
-        { ("SDL_GetRenderScale", "scaleX"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1662:34
-        { ("SDL_GetRenderScale", "scaleY"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1662:34
-        { ("SDL_GetRenderDrawColor", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
-        { ("SDL_GetRenderDrawColor", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
-        { ("SDL_GetRenderDrawColor", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
-        { ("SDL_GetRenderDrawColor", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
-        { ("SDL_GetRenderDrawColorFloat", "r"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
-        { ("SDL_GetRenderDrawColorFloat", "g"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
-        { ("SDL_GetRenderDrawColorFloat", "b"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
-        { ("SDL_GetRenderDrawColorFloat", "a"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
-        { ("SDL_GetRenderColorScale", "scale"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1800:34
-        { ("SDL_RenderPoints", "points"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1888:34
-        { ("SDL_RenderLines", "points"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1925:34
-        { ("SDL_RenderRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1942:34
-        { ("SDL_RenderRects", "rects"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1960:34
-        { ("SDL_RenderFillRect", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1978:34
-        { ("SDL_RenderFillRects", "rects"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1996:34
-        { ("SDL_RenderTexture", "srcrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2018:34
-        { ("SDL_RenderTexture", "dstrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2018:34
-        { ("SDL_RenderTextureRotated", "srcrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
-        { ("SDL_RenderTextureRotated", "dstrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
-        { ("SDL_RenderTextureRotated", "center"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
-        { ("SDL_RenderTextureTiled", "srcrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2076:34
-        { ("SDL_RenderTextureTiled", "dstrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2076:34
-        { ("SDL_RenderTexture9Grid", "srcrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2110:34
-        { ("SDL_RenderTexture9Grid", "dstrect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2110:34
-        { ("SDL_RenderGeometry", "vertices"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:2134:34
-        { ("SDL_RenderGeometry", "indices"), PointerParameterIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:2134:34
-        { ("SDL_RenderGeometryRaw", "xy"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
-        { ("SDL_RenderGeometryRaw", "color"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
-        { ("SDL_RenderGeometryRaw", "uv"), PointerParameterIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
-        { ("SDL_RenderReadPixels", "rect"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2193:43
-        { ("SDL_GetRenderVSync", "vsync"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:2426:34
-        { ("SDL_GetTextureProperties", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:808:46
-        { ("SDL_GetRendererFromTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:848:44
-        { ("SDL_GetTextureSize", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:865:34
-        { ("SDL_SetTextureColorMod", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:894:34
-        { ("SDL_SetTextureColorModFloat", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:924:34
-        { ("SDL_GetTextureColorMod", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:945:34
-        { ("SDL_GetTextureColorModFloat", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:965:34
-        { ("SDL_SetTextureAlphaMod", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:991:34
-        { ("SDL_SetTextureAlphaModFloat", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1017:34
-        { ("SDL_GetTextureAlphaMod", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1035:34
-        { ("SDL_GetTextureAlphaModFloat", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1053:34
-        { ("SDL_SetTextureBlendMode", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1072:34
-        { ("SDL_GetTextureBlendMode", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1088:34
-        { ("SDL_SetTextureScaleMode", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1108:34
-        { ("SDL_GetTextureScaleMode", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1124:34
-        { ("SDL_UpdateTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1158:34
-        { ("SDL_UpdateYUVTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1190:34
-        { ("SDL_UpdateNVTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1222:34
-        { ("SDL_LockTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1257:34
-        { ("SDL_LockTextureToSurface", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1295:34
-        { ("SDL_UnlockTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1316:34
-        { ("SDL_SetRenderTarget", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1338:34
-        { ("SDL_RenderTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2057:34
-        { ("SDL_RenderTextureRotated", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2085:34
-        { ("SDL_RenderTextureTiled", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2115:34
-        { ("SDL_RenderTexture9Grid", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2149:34
-        { ("SDL_RenderGeometry", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2173:34
-        { ("SDL_RenderGeometryRaw", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2205:34
-        { ("SDL_DestroyTexture", "texture"), PointerParameterIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2299:34
-        { ("SDL_OpenStorage", "iface"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_storage.h:215:43
-        { ("SDL_GetStorageFileSize", "length"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:263:34
-        { ("SDL_GetStoragePathInfo", "info"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:398:34
-        { ("SDL_GlobStorageDirectory", "count"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:448:37
-        { ("SDL_GetDateTimeLocalePreferences", "dateFormat"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:103:34
-        { ("SDL_GetDateTimeLocalePreferences", "timeFormat"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:103:34
-        { ("SDL_TimeToDateTime", "dt"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:131:34
-        { ("SDL_DateTimeToTime", "dt"), PointerParameterIntent.Ref }, // /usr/local/include/SDL3/SDL_time.h:146:34
-        { ("SDL_TimeToWindows", "dwLowDateTime"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:162:34
-        { ("SDL_TimeToWindows", "dwHighDateTime"), PointerParameterIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:162:34
+        { ("SDL_AcquireCameraFrame", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_camera.h:433:43
+        { ("SDL_AcquireCameraFrame", "timestampNS"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:431:43
+        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
+        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture_height"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
+        { ("SDL_AcquireGPUSwapchainTexture", "swapchain_texture_width"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gpu.h:3380:34
+        { ("SDL_AddAtomicInt", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:406:33
+        { ("SDL_AddSurfaceAlternateImage", "image"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:333:34
+        { ("SDL_AddSurfaceAlternateImage", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:333:34
+        { ("SDL_AttachVirtualJoystick", "desc"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_joystick.h:482:44
+        { ("SDL_BeginGPUComputePass", "storage_buffer_bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2866:49
+        { ("SDL_BeginGPUComputePass", "storage_texture_bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2866:49
+        { ("SDL_BeginGPURenderPass", "color_target_infos"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2493:48
+        { ("SDL_BeginGPURenderPass", "depth_stencil_target_info"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2493:48
+        { ("SDL_BindAudioStreams", "streams"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:838:34
+        { ("SDL_BindGPUComputeSamplers", "texture_sampler_bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2899:34
+        { ("SDL_BindGPUComputeStorageBuffers", "storage_buffers"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2937:34
+        { ("SDL_BindGPUComputeStorageTextures", "storage_textures"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2918:34
+        { ("SDL_BindGPUFragmentSamplers", "texture_sampler_bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2670:34
+        { ("SDL_BindGPUFragmentStorageBuffers", "storage_buffers"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2708:34
+        { ("SDL_BindGPUFragmentStorageTextures", "storage_textures"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2689:34
+        { ("SDL_BindGPUIndexBuffer", "binding"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2593:34
+        { ("SDL_BindGPUVertexBuffers", "bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2576:34
+        { ("SDL_BindGPUVertexSamplers", "texture_sampler_bindings"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2612:34
+        { ("SDL_BindGPUVertexStorageBuffers", "storage_buffers"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2650:34
+        { ("SDL_BindGPUVertexStorageTextures", "storage_textures"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:2631:34
+        { ("SDL_BlitGPUTexture", "info"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3218:34
+        { ("SDL_BlitSurface", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
+        { ("SDL_BlitSurface", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
+        { ("SDL_BlitSurface", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
+        { ("SDL_BlitSurface", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1077:34
+        { ("SDL_BlitSurface9Grid", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
+        { ("SDL_BlitSurface9Grid", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
+        { ("SDL_BlitSurface9Grid", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
+        { ("SDL_BlitSurface9Grid", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1246:34
+        { ("SDL_BlitSurfaceScaled", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
+        { ("SDL_BlitSurfaceScaled", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
+        { ("SDL_BlitSurfaceScaled", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
+        { ("SDL_BlitSurfaceScaled", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1127:34
+        { ("SDL_BlitSurfaceTiled", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
+        { ("SDL_BlitSurfaceTiled", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
+        { ("SDL_BlitSurfaceTiled", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
+        { ("SDL_BlitSurfaceTiled", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1179:34
+        { ("SDL_BlitSurfaceTiledWithScale", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
+        { ("SDL_BlitSurfaceTiledWithScale", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
+        { ("SDL_BlitSurfaceTiledWithScale", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
+        { ("SDL_BlitSurfaceTiledWithScale", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1209:34
+        { ("SDL_BlitSurfaceUnchecked", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
+        { ("SDL_BlitSurfaceUnchecked", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
+        { ("SDL_BlitSurfaceUnchecked", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
+        { ("SDL_BlitSurfaceUnchecked", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1102:34
+        { ("SDL_BlitSurfaceUncheckedScaled", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
+        { ("SDL_BlitSurfaceUncheckedScaled", "dstrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
+        { ("SDL_BlitSurfaceUncheckedScaled", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
+        { ("SDL_BlitSurfaceUncheckedScaled", "srcrect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:1153:34
+        { ("SDL_ClearSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:952:34
+        { ("SDL_CompareAndSwapAtomicInt", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:348:34
+        { ("SDL_CompareAndSwapAtomicPointer", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:548:34
+        { ("SDL_CompareAndSwapAtomicU32", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:490:34
+        { ("SDL_ConvertAudioSamples", "dst_data"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
+        { ("SDL_ConvertAudioSamples", "dst_len"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
+        { ("SDL_ConvertAudioSamples", "dst_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
+        { ("SDL_ConvertAudioSamples", "src_data"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
+        { ("SDL_ConvertAudioSamples", "src_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1981:34
+        { ("SDL_ConvertEventToRenderCoordinates", "event"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1485:34
+        { ("SDL_ConvertSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:835:43
+        { ("SDL_ConvertSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:819:43
+        { ("SDL_ConvertSurfaceAndColorspace", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:862:43
+        { ("SDL_ConvertSurfaceAndColorspace", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:846:43
+        { ("SDL_ConvertSurfaceAndColorspace", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:846:43
+        { ("SDL_CopyGPUBufferToBuffer", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3142:34
+        { ("SDL_CopyGPUBufferToBuffer", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3142:34
+        { ("SDL_CopyGPUTextureToTexture", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3116:34
+        { ("SDL_CopyGPUTextureToTexture", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3116:34
+        { ("SDL_CreateAudioStream", "dst_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:937:47
+        { ("SDL_CreateAudioStream", "src_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:937:47
+        { ("SDL_CreateColorCursor", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:460:42
+        { ("SDL_CreateCursor", "data"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:429:42
+        { ("SDL_CreateCursor", "mask"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_mouse.h:429:42
+        { ("SDL_CreateGPUBuffer", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2122:44
+        { ("SDL_CreateGPUComputePipeline", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1946:53
+        { ("SDL_CreateGPUGraphicsPipeline", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1965:54
+        { ("SDL_CreateGPUSampler", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:1984:45
+        { ("SDL_CreateGPUShader", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2053:44
+        { ("SDL_CreateGPUTexture", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2088:45
+        { ("SDL_CreateGPUTransferBuffer", "createinfo"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2144:52
+        { ("SDL_CreateHapticEffect", "effect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1184:33
+        { ("SDL_CreatePalette", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_pixels.h:846:43
+        { ("SDL_CreateSoftwareRenderer", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:312:44
+        { ("SDL_CreateSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:156:43
+        { ("SDL_CreateSurfaceFrom", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:184:43
+        { ("SDL_CreateSurfacePalette", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:294:43
+        { ("SDL_CreateSurfacePalette", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:278:43
+        { ("SDL_CreateTexture", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_render.h:544:43
+        { ("SDL_CreateTextureFromSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_render.h:572:43
+        { ("SDL_CreateTextureFromSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:555:43
+        { ("SDL_CreateTextureWithProperties", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_render.h:685:43
+        { ("SDL_CreateWindowAndRenderer", "renderer"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:194:34
+        { ("SDL_CreateWindowAndRenderer", "window"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:194:34
+        { ("SDL_DateTimeToTime", "dt"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_time.h:146:34
+        { ("SDL_DestroyPalette", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:877:34
+        { ("SDL_DestroySurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:183:34
+        { ("SDL_DestroyTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2299:34
+        { ("SDL_DownloadFromGPUBuffer", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3179:34
+        { ("SDL_DownloadFromGPUBuffer", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3179:34
+        { ("SDL_DownloadFromGPUTexture", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3162:34
+        { ("SDL_DownloadFromGPUTexture", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3162:34
+        { ("SDL_DuplicateSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:790:43
+        { ("SDL_DuplicateSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:774:43
+        { ("SDL_FillSurfaceRect", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:977:34
+        { ("SDL_FillSurfaceRect", "rect"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_surface.h:977:34
+        { ("SDL_FillSurfaceRects", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1002:34
+        { ("SDL_FillSurfaceRects", "rects"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_surface.h:1002:34
+        { ("SDL_FlipSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:756:34
+        { ("SDL_GL_GetAttribute", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2648:34
+        { ("SDL_GL_GetSwapInterval", "interval"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2813:34
+        { ("SDL_GetAssertionHandler", "puserdata"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_assert.h:489:50
+        { ("SDL_GetAssertionReport", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_assert.h:542:52
+        { ("SDL_GetAtomicInt", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:385:33
+        { ("SDL_GetAtomicPointer", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:585:36
+        { ("SDL_GetAtomicU32", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:527:36
+        { ("SDL_GetAudioDeviceChannelMap", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:565:35
+        { ("SDL_GetAudioDeviceChannelMap", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:565:35
+        { ("SDL_GetAudioDeviceFormat", "sample_frames"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:542:34
+        { ("SDL_GetAudioDeviceFormat", "spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:542:34
+        { ("SDL_GetAudioPlaybackDevices", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:461:49
+        { ("SDL_GetAudioRecordingDevices", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:490:49
+        { ("SDL_GetAudioStreamFormat", "dst_spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:966:34
+        { ("SDL_GetAudioStreamFormat", "src_spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:966:34
+        { ("SDL_GetAudioStreamInputChannelMap", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1136:35
+        { ("SDL_GetAudioStreamInputChannelMap", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1111:35
+        { ("SDL_GetAudioStreamOutputChannelMap", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1160:35
+        { ("SDL_GetAudioStreamOutputChannelMap", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1135:35
+        { ("SDL_GetCameraFormat", "spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:388:34
+        { ("SDL_GetCameraSupportedFormats", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_camera.h:222:47
+        { ("SDL_GetCameraSupportedFormats", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:222:47
+        { ("SDL_GetCameras", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_camera.h:183:44
+        { ("SDL_GetClipboardData", "size"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_clipboard.h:227:36
+        { ("SDL_GetClipboardMimeTypes", "num_mime_types"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_clipboard.h:256:37
+        { ("SDL_GetClosestFullscreenDisplayMode", "mode"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:609:34
+        { ("SDL_GetCurrentDisplayMode", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_video.h:716:53
+        { ("SDL_GetCurrentRenderOutputSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:501:34
+        { ("SDL_GetCurrentRenderOutputSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:501:34
+        { ("SDL_GetDateTimeLocalePreferences", "dateFormat"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:103:34
+        { ("SDL_GetDateTimeLocalePreferences", "timeFormat"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:103:34
+        { ("SDL_GetDesktopDisplayMode", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_video.h:697:53
+        { ("SDL_GetDisplayBounds", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:486:34
+        { ("SDL_GetDisplayForPoint", "point"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:661:43
+        { ("SDL_GetDisplayForRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:676:43
+        { ("SDL_GetDisplayUsableBounds", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:510:34
+        { ("SDL_GetDisplays", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:415:45
+        { ("SDL_GetEventFilter", "filter"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1348:34
+        { ("SDL_GetEventFilter", "userdata"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1348:34
+        { ("SDL_GetFullscreenDisplayModes", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_video.h:649:48
+        { ("SDL_GetFullscreenDisplayModes", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:580:48
+        { ("SDL_GetGamepadBindings", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gamepad.h:1031:51
+        { ("SDL_GetGamepadBindings", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1011:51
+        { ("SDL_GetGamepadMappings", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:403:37
+        { ("SDL_GetGamepadPowerInfo", "percent"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:936:44
+        { ("SDL_GetGamepadSensorData", "data"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_gamepad.h:1340:34
+        { ("SDL_GetGamepadTouchpadFinger", "down"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
+        { ("SDL_GetGamepadTouchpadFinger", "pressure"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
+        { ("SDL_GetGamepadTouchpadFinger", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
+        { ("SDL_GetGamepadTouchpadFinger", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:1268:34
+        { ("SDL_GetGamepads", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_gamepad.h:482:46
+        { ("SDL_GetGlobalMouseState", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:243:50
+        { ("SDL_GetGlobalMouseState", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:243:50
+        { ("SDL_GetHaptics", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_haptic.h:943:44
+        { ("SDL_GetJoystickAxisInitialState", "state"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1013:34
+        { ("SDL_GetJoystickBall", "dx"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1034:34
+        { ("SDL_GetJoystickBall", "dy"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1034:34
+        { ("SDL_GetJoystickGUIDInfo", "crc16"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
+        { ("SDL_GetJoystickGUIDInfo", "product"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
+        { ("SDL_GetJoystickGUIDInfo", "vendor"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
+        { ("SDL_GetJoystickGUIDInfo", "version"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:837:34
+        { ("SDL_GetJoystickPowerInfo", "percent"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:1200:44
+        { ("SDL_GetJoysticks", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_joystick.h:215:46
+        { ("SDL_GetKeyboardState", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_keyboard.h:144:42
+        { ("SDL_GetKeyboardState", "numkeys"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:144:42
+        { ("SDL_GetKeyboards", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:89:46
+        { ("SDL_GetLogOutputFunction", "callback"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_log.h:490:34
+        { ("SDL_GetLogOutputFunction", "userdata"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_log.h:490:34
+        { ("SDL_GetMasksForPixelFormat", "Amask"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
+        { ("SDL_GetMasksForPixelFormat", "Bmask"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
+        { ("SDL_GetMasksForPixelFormat", "Gmask"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
+        { ("SDL_GetMasksForPixelFormat", "Rmask"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
+        { ("SDL_GetMasksForPixelFormat", "bpp"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:787:34
+        { ("SDL_GetMice", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:167:43
+        { ("SDL_GetMouseState", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:213:50
+        { ("SDL_GetMouseState", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:213:50
+        { ("SDL_GetPathInfo", "info"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_filesystem.h:413:34
+        { ("SDL_GetPixelFormatDetails", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_pixels.h:826:60
+        { ("SDL_GetPowerInfo", "percent"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_power.h:85:44
+        { ("SDL_GetPowerInfo", "seconds"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_power.h:85:44
+        { ("SDL_GetPreferredLocales", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_locale.h:101:43
+        { ("SDL_GetPreferredLocales", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_locale.h:101:43
+        { ("SDL_GetRGB", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
+        { ("SDL_GetRGB", "format"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
+        { ("SDL_GetRGB", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
+        { ("SDL_GetRGB", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
+        { ("SDL_GetRGB", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:982:34
+        { ("SDL_GetRGBA", "a"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRGBA", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRGBA", "format"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRGBA", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRGBA", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRGBA", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_pixels.h:1014:34
+        { ("SDL_GetRectAndLineIntersection", "X1"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
+        { ("SDL_GetRectAndLineIntersection", "X2"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
+        { ("SDL_GetRectAndLineIntersection", "Y1"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
+        { ("SDL_GetRectAndLineIntersection", "Y2"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
+        { ("SDL_GetRectAndLineIntersection", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:294:34
+        { ("SDL_GetRectAndLineIntersectionFloat", "X1"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
+        { ("SDL_GetRectAndLineIntersectionFloat", "X2"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
+        { ("SDL_GetRectAndLineIntersectionFloat", "Y1"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
+        { ("SDL_GetRectAndLineIntersectionFloat", "Y2"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
+        { ("SDL_GetRectAndLineIntersectionFloat", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:499:34
+        { ("SDL_GetRectEnclosingPoints", "clip"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:274:34
+        { ("SDL_GetRectEnclosingPoints", "points"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_rect.h:274:34
+        { ("SDL_GetRectEnclosingPoints", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:274:34
+        { ("SDL_GetRectEnclosingPointsFloat", "clip"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:478:34
+        { ("SDL_GetRectEnclosingPointsFloat", "points"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_rect.h:478:34
+        { ("SDL_GetRectEnclosingPointsFloat", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:478:34
+        { ("SDL_GetRectIntersection", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:241:34
+        { ("SDL_GetRectIntersection", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:241:34
+        { ("SDL_GetRectIntersection", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:241:34
+        { ("SDL_GetRectIntersectionFloat", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:444:34
+        { ("SDL_GetRectIntersectionFloat", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:444:34
+        { ("SDL_GetRectIntersectionFloat", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:444:34
+        { ("SDL_GetRectUnion", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:255:34
+        { ("SDL_GetRectUnion", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:255:34
+        { ("SDL_GetRectUnion", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:255:34
+        { ("SDL_GetRectUnionFloat", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:458:34
+        { ("SDL_GetRectUnionFloat", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:458:34
+        { ("SDL_GetRectUnionFloat", "result"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_rect.h:458:34
+        { ("SDL_GetRelativeMouseState", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:262:50
+        { ("SDL_GetRelativeMouseState", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_mouse.h:262:50
+        { ("SDL_GetRenderClipRect", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1604:34
+        { ("SDL_GetRenderColorScale", "scale"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1800:34
+        { ("SDL_GetRenderDrawColor", "a"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
+        { ("SDL_GetRenderDrawColor", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
+        { ("SDL_GetRenderDrawColor", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
+        { ("SDL_GetRenderDrawColor", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1736:34
+        { ("SDL_GetRenderDrawColorFloat", "a"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
+        { ("SDL_GetRenderDrawColorFloat", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
+        { ("SDL_GetRenderDrawColorFloat", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
+        { ("SDL_GetRenderDrawColorFloat", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1760:34
+        { ("SDL_GetRenderLogicalPresentation", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
+        { ("SDL_GetRenderLogicalPresentation", "mode"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
+        { ("SDL_GetRenderLogicalPresentation", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1400:34
+        { ("SDL_GetRenderLogicalPresentationRect", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1422:34
+        { ("SDL_GetRenderOutputSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:479:34
+        { ("SDL_GetRenderOutputSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:479:34
+        { ("SDL_GetRenderSafeArea", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1568:34
+        { ("SDL_GetRenderScale", "scaleX"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1662:34
+        { ("SDL_GetRenderScale", "scaleY"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1662:34
+        { ("SDL_GetRenderTarget", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_render.h:1355:43
+        { ("SDL_GetRenderVSync", "vsync"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:2426:34
+        { ("SDL_GetRenderViewport", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1526:34
+        { ("SDL_GetRendererFromTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:848:44
+        { ("SDL_GetSensorData", "data"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_sensor.h:280:34
+        { ("SDL_GetSensors", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_sensor.h:151:44
+        { ("SDL_GetStorageFileSize", "length"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:263:34
+        { ("SDL_GetStoragePathInfo", "info"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:398:34
+        { ("SDL_GetSurfaceAlphaMod", "alpha"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:672:34
+        { ("SDL_GetSurfaceAlphaMod", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:672:34
+        { ("SDL_GetSurfaceBlendMode", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:704:34
+        { ("SDL_GetSurfaceClipRect", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:744:34
+        { ("SDL_GetSurfaceClipRect", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:744:34
+        { ("SDL_GetSurfaceColorKey", "key"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:596:34
+        { ("SDL_GetSurfaceColorKey", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:596:34
+        { ("SDL_GetSurfaceColorMod", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
+        { ("SDL_GetSurfaceColorMod", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
+        { ("SDL_GetSurfaceColorMod", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:637:34
+        { ("SDL_GetSurfaceColorMod", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:637:34
+        { ("SDL_GetSurfaceColorspace", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:250:44
+        { ("SDL_GetSurfaceImages", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_surface.h:388:44
+        { ("SDL_GetSurfaceImages", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:372:44
+        { ("SDL_GetSurfaceImages", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:372:44
+        { ("SDL_GetSurfacePalette", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:324:43
+        { ("SDL_GetSurfacePalette", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:308:43
+        { ("SDL_GetSurfaceProperties", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:211:46
+        { ("SDL_GetTextInputArea", "cursor"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:518:34
+        { ("SDL_GetTextInputArea", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_keyboard.h:518:34
+        { ("SDL_GetTextureAlphaMod", "alpha"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1018:34
+        { ("SDL_GetTextureAlphaMod", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1035:34
+        { ("SDL_GetTextureAlphaModFloat", "alpha"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1036:34
+        { ("SDL_GetTextureAlphaModFloat", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1053:34
+        { ("SDL_GetTextureBlendMode", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1088:34
+        { ("SDL_GetTextureColorMod", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
+        { ("SDL_GetTextureColorMod", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
+        { ("SDL_GetTextureColorMod", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:928:34
+        { ("SDL_GetTextureColorMod", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:945:34
+        { ("SDL_GetTextureColorModFloat", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
+        { ("SDL_GetTextureColorModFloat", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
+        { ("SDL_GetTextureColorModFloat", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:948:34
+        { ("SDL_GetTextureColorModFloat", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:965:34
+        { ("SDL_GetTextureProperties", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:808:46
+        { ("SDL_GetTextureScaleMode", "scaleMode"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1107:34
+        { ("SDL_GetTextureScaleMode", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1124:34
+        { ("SDL_GetTextureSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:848:34
+        { ("SDL_GetTextureSize", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:865:34
+        { ("SDL_GetTextureSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:848:34
+        { ("SDL_GetTouchDevices", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:93:43
+        { ("SDL_GetTouchFingers", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_touch.h:129:43
+        { ("SDL_GetTouchFingers", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_touch.h:129:43
+        { ("SDL_GetWindowAspectRatio", "max_aspect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1562:34
+        { ("SDL_GetWindowAspectRatio", "min_aspect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1562:34
+        { ("SDL_GetWindowBordersSize", "bottom"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
+        { ("SDL_GetWindowBordersSize", "left"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
+        { ("SDL_GetWindowBordersSize", "right"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
+        { ("SDL_GetWindowBordersSize", "top"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1597:34
+        { ("SDL_GetWindowFromEvent", "event"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_events.h:1465:42
+        { ("SDL_GetWindowFullscreenMode", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_video.h:846:53
+        { ("SDL_GetWindowICCProfile", "size"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:790:36
+        { ("SDL_GetWindowMaximumSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1683:34
+        { ("SDL_GetWindowMaximumSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1683:34
+        { ("SDL_GetWindowMinimumSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1649:34
+        { ("SDL_GetWindowMinimumSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1649:34
+        { ("SDL_GetWindowMouseRect", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_video.h:2264:46
+        { ("SDL_GetWindowPosition", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1429:34
+        { ("SDL_GetWindowPosition", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1429:34
+        { ("SDL_GetWindowSafeArea", "rect"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1506:34
+        { ("SDL_GetWindowSize", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1486:34
+        { ("SDL_GetWindowSize", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1486:34
+        { ("SDL_GetWindowSizeInPixels", "h"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1615:34
+        { ("SDL_GetWindowSizeInPixels", "w"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:1615:34
+        { ("SDL_GetWindowSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_video.h:2046:43
+        { ("SDL_GetWindowSurfaceVSync", "vsync"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:2006:34
+        { ("SDL_GetWindows", "__return"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_video.h:885:43
+        { ("SDL_GetWindows", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_video.h:816:43
+        { ("SDL_GlobDirectory", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_filesystem.h:446:37
+        { ("SDL_GlobStorageDirectory", "count"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_storage.h:448:37
+        { ("SDL_HapticEffectSupported", "effect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1167:34
+        { ("SDL_HasRectIntersection", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
+        { ("SDL_HasRectIntersection", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:224:34
+        { ("SDL_HasRectIntersectionFloat", "A"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
+        { ("SDL_HasRectIntersectionFloat", "B"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_rect.h:427:34
+        { ("SDL_LoadBMP", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:476:43
+        { ("SDL_LoadBMP_IO", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:458:43
+        { ("SDL_LoadFile", "datasize"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:671:36
+        { ("SDL_LoadFile_IO", "datasize"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:651:36
+        { ("SDL_LoadWAV", "audio_buf"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
+        { ("SDL_LoadWAV", "audio_len"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
+        { ("SDL_LoadWAV", "spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1915:34
+        { ("SDL_LoadWAV_IO", "audio_buf"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
+        { ("SDL_LoadWAV_IO", "audio_len"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
+        { ("SDL_LoadWAV_IO", "spec"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_audio.h:1879:34
+        { ("SDL_LockSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:411:34
+        { ("SDL_LockTexture", "pitch"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1240:34
+        { ("SDL_LockTexture", "pixels"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1240:34
+        { ("SDL_LockTexture", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1240:34
+        { ("SDL_LockTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1257:34
+        { ("SDL_LockTextureToSurface", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1278:34
+        { ("SDL_LockTextureToSurface", "surface"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1278:34
+        { ("SDL_LockTextureToSurface", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1295:34
+        { ("SDL_MapRGB", "format"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:915:36
+        { ("SDL_MapRGB", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:915:36
+        { ("SDL_MapRGBA", "format"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:954:36
+        { ("SDL_MapRGBA", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:954:36
+        { ("SDL_MapSurfaceRGB", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1276:36
+        { ("SDL_MapSurfaceRGBA", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1307:36
+        { ("SDL_MixAudio", "dst"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1951:34
+        { ("SDL_MixAudio", "src"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_audio.h:1951:34
+        { ("SDL_OpenAudioDevice", "spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:641:47
+        { ("SDL_OpenAudioDeviceStream", "spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:1707:47
+        { ("SDL_OpenCamera", "spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_camera.h:302:42
+        { ("SDL_OpenIO", "iface"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_iostream.h:402:44
+        { ("SDL_OpenStorage", "iface"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_storage.h:215:43
+        { ("SDL_PeepEvents", "events"), PointerFunctionDataIntent.OutArray }, // /usr/local/include/SDL3/SDL_events.h:1047:33
+        { ("SDL_PollEvent", "event"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1178:34
+        { ("SDL_PremultiplySurfaceAlpha", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:932:34
+        { ("SDL_PushEvent", "event"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_events.h:1262:34
+        { ("SDL_ReadProcess", "datasize"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:283:36
+        { ("SDL_ReadProcess", "exitcode"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:283:36
+        { ("SDL_ReadS16BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:766:34
+        { ("SDL_ReadS16LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:734:34
+        { ("SDL_ReadS32BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:830:34
+        { ("SDL_ReadS32LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:798:34
+        { ("SDL_ReadS64BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:894:34
+        { ("SDL_ReadS64LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:862:34
+        { ("SDL_ReadS8", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:702:34
+        { ("SDL_ReadSurfacePixel", "a"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
+        { ("SDL_ReadSurfacePixel", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
+        { ("SDL_ReadSurfacePixel", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
+        { ("SDL_ReadSurfacePixel", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
+        { ("SDL_ReadSurfacePixel", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1334:34
+        { ("SDL_ReadSurfacePixelFloat", "a"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
+        { ("SDL_ReadSurfacePixelFloat", "b"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
+        { ("SDL_ReadSurfacePixelFloat", "g"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
+        { ("SDL_ReadSurfacePixelFloat", "r"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
+        { ("SDL_ReadSurfacePixelFloat", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1358:34
+        { ("SDL_ReadU16BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:750:34
+        { ("SDL_ReadU16LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:718:34
+        { ("SDL_ReadU32BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:814:34
+        { ("SDL_ReadU32LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:782:34
+        { ("SDL_ReadU64BE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:878:34
+        { ("SDL_ReadU64LE", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:846:34
+        { ("SDL_ReadU8", "value"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_iostream.h:690:34
+        { ("SDL_ReleaseCameraFrame", "frame"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_camera.h:459:34
+        { ("SDL_RemoveSurfaceAlternateImages", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:388:34
+        { ("SDL_RenderCoordinatesFromWindow", "x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1442:34
+        { ("SDL_RenderCoordinatesFromWindow", "y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1442:34
+        { ("SDL_RenderCoordinatesToWindow", "window_x"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1464:34
+        { ("SDL_RenderCoordinatesToWindow", "window_y"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_render.h:1464:34
+        { ("SDL_RenderFillRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1978:34
+        { ("SDL_RenderFillRects", "rects"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1996:34
+        { ("SDL_RenderGeometry", "indices"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:2134:34
+        { ("SDL_RenderGeometry", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2173:34
+        { ("SDL_RenderGeometry", "vertices"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:2134:34
+        { ("SDL_RenderGeometryRaw", "color"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
+        { ("SDL_RenderGeometryRaw", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2205:34
+        { ("SDL_RenderGeometryRaw", "uv"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
+        { ("SDL_RenderGeometryRaw", "xy"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:2166:34
+        { ("SDL_RenderLines", "points"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1925:34
+        { ("SDL_RenderPoints", "points"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1888:34
+        { ("SDL_RenderReadPixels", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_render.h:2232:43
+        { ("SDL_RenderReadPixels", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2193:43
+        { ("SDL_RenderRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1942:34
+        { ("SDL_RenderRects", "rects"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_render.h:1960:34
+        { ("SDL_RenderTexture", "dstrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2018:34
+        { ("SDL_RenderTexture", "srcrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2018:34
+        { ("SDL_RenderTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2057:34
+        { ("SDL_RenderTexture9Grid", "dstrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2110:34
+        { ("SDL_RenderTexture9Grid", "srcrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2110:34
+        { ("SDL_RenderTexture9Grid", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2149:34
+        { ("SDL_RenderTextureRotated", "center"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
+        { ("SDL_RenderTextureRotated", "dstrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
+        { ("SDL_RenderTextureRotated", "srcrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2046:34
+        { ("SDL_RenderTextureRotated", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2085:34
+        { ("SDL_RenderTextureTiled", "dstrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2076:34
+        { ("SDL_RenderTextureTiled", "srcrect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:2076:34
+        { ("SDL_RenderTextureTiled", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:2115:34
+        { ("SDL_ReportAssertion", "data"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_assert.h:245:45
+        { ("SDL_SaveBMP", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:504:34
+        { ("SDL_SaveBMP_IO", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:483:34
+        { ("SDL_ScaleSurface", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_surface.h:809:43
+        { ("SDL_ScaleSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:793:43
+        { ("SDL_SendJoystickVirtualSensorData", "data"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_joystick.h:635:34
+        { ("SDL_SetAtomicInt", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:368:33
+        { ("SDL_SetAtomicPointer", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:567:36
+        { ("SDL_SetAtomicU32", "a"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_atomic.h:510:36
+        { ("SDL_SetAudioStreamFormat", "dst_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:997:34
+        { ("SDL_SetAudioStreamFormat", "src_spec"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_audio.h:997:34
+        { ("SDL_SetAudioStreamInputChannelMap", "chmap"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1186:34
+        { ("SDL_SetAudioStreamOutputChannelMap", "chmap"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:1233:34
+        { ("SDL_SetGPUScissor", "scissor"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2533:34
+        { ("SDL_SetGPUViewport", "viewport"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:2521:34
+        { ("SDL_SetInitialized", "state"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:904:34
+        { ("SDL_SetPaletteColors", "colors"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_pixels.h:863:34
+        { ("SDL_SetPaletteColors", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_pixels.h:863:34
+        { ("SDL_SetRenderClipRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1586:34
+        { ("SDL_SetRenderTarget", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1338:34
+        { ("SDL_SetRenderViewport", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1509:34
+        { ("SDL_SetSurfaceAlphaMod", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:657:34
+        { ("SDL_SetSurfaceBlendMode", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:690:34
+        { ("SDL_SetSurfaceClipRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_surface.h:725:34
+        { ("SDL_SetSurfaceClipRect", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:725:34
+        { ("SDL_SetSurfaceColorKey", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:561:34
+        { ("SDL_SetSurfaceColorMod", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:619:34
+        { ("SDL_SetSurfaceColorspace", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:233:34
+        { ("SDL_SetSurfacePalette", "palette"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:295:34
+        { ("SDL_SetSurfacePalette", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:295:34
+        { ("SDL_SetSurfaceRLE", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:523:34
+        { ("SDL_SetTextInputArea", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_keyboard.h:499:34
+        { ("SDL_SetTextureAlphaMod", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:991:34
+        { ("SDL_SetTextureAlphaModFloat", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1017:34
+        { ("SDL_SetTextureBlendMode", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1072:34
+        { ("SDL_SetTextureColorMod", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:894:34
+        { ("SDL_SetTextureColorModFloat", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:924:34
+        { ("SDL_SetTextureScaleMode", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1108:34
+        { ("SDL_SetWindowFullscreenMode", "mode"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:763:34
+        { ("SDL_SetWindowIcon", "icon"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_video.h:1366:34
+        { ("SDL_SetWindowMouseRect", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_video.h:2169:34
+        { ("SDL_SetWindowShape", "shape"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_video.h:2396:34
+        { ("SDL_ShouldInit", "state"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:864:34
+        { ("SDL_ShouldQuit", "state"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_mutex.h:885:34
+        { ("SDL_ShowMessageBox", "buttonid"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_messagebox.h:164:34
+        { ("SDL_ShowMessageBox", "messageboxdata"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_messagebox.h:164:34
+        { ("SDL_ShowOpenFileDialog", "filters"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_dialog.h:154:34
+        { ("SDL_ShowSaveFileDialog", "filters"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_dialog.h:209:34
+        { ("SDL_SurfaceHasAlternateImages", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:347:34
+        { ("SDL_SurfaceHasColorKey", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:576:34
+        { ("SDL_SurfaceHasRLE", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:537:34
+        { ("SDL_TimeToDateTime", "dt"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:131:34
+        { ("SDL_TimeToWindows", "dwHighDateTime"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:162:34
+        { ("SDL_TimeToWindows", "dwLowDateTime"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_time.h:162:34
+        { ("SDL_UnbindAudioStreams", "streams"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_audio.h:879:34
+        { ("SDL_UnlockSurface", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:422:34
+        { ("SDL_UnlockTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1316:34
+        { ("SDL_UpdateHapticEffect", "data"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_haptic.h:1206:34
+        { ("SDL_UpdateNVTexture", "UVplane"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1205:34
+        { ("SDL_UpdateNVTexture", "Yplane"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1205:34
+        { ("SDL_UpdateNVTexture", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1205:34
+        { ("SDL_UpdateNVTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1222:34
+        { ("SDL_UpdateTexture", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1141:34
+        { ("SDL_UpdateTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1158:34
+        { ("SDL_UpdateWindowSurfaceRects", "rects"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_video.h:2052:34
+        { ("SDL_UpdateYUVTexture", "Uplane"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
+        { ("SDL_UpdateYUVTexture", "Vplane"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
+        { ("SDL_UpdateYUVTexture", "Yplane"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_render.h:1173:34
+        { ("SDL_UpdateYUVTexture", "rect"), PointerFunctionDataIntent.Ref }, // /usr/local/include/SDL3/SDL_render.h:1173:34
+        { ("SDL_UpdateYUVTexture", "texture"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_render.h:1190:34
+        { ("SDL_UploadToGPUBuffer", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3093:34
+        { ("SDL_UploadToGPUBuffer", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3093:34
+        { ("SDL_UploadToGPUTexture", "destination"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3071:34
+        { ("SDL_UploadToGPUTexture", "source"), PointerFunctionDataIntent.In }, // /usr/local/include/SDL3/SDL_gpu.h:3071:34
+        { ("SDL_WaitEvent", "event"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1200:34
+        { ("SDL_WaitEventTimeout", "event"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_events.h:1228:34
+        { ("SDL_WaitForGPUFences", "fences"), PointerFunctionDataIntent.Array }, // /usr/local/include/SDL3/SDL_gpu.h:3466:34
+        { ("SDL_WaitProcess", "exitcode"), PointerFunctionDataIntent.Out }, // /usr/local/include/SDL3/SDL_process.h:383:34
+        { ("SDL_WaitThread", "status"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_thread.h:423:34
+        { ("SDL_WriteSurfacePixel", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1381:34
+        { ("SDL_WriteSurfacePixelFloat", "surface"), PointerFunctionDataIntent.IntPtr }, // /usr/local/include/SDL3/SDL_surface.h:1401:34
+        { ("SDL_hid_enumerate", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_hidapi.h:240:51
+        { ("SDL_hid_free_enumeration", "devs"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:252:34
+        { ("SDL_hid_get_device_info", "__return"), PointerFunctionDataIntent.Pointer }, // /usr/local/include/SDL3/SDL_hidapi.h:519:51
+        { ("SDL_hid_get_feature_report", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:420:33
+        { ("SDL_hid_get_input_report", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:443:33
+        { ("SDL_hid_get_report_descriptor", "buf"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:535:33
+        { ("SDL_hid_read", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:353:33
+        { ("SDL_hid_read_timeout", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:332:33
+        { ("SDL_hid_send_feature_report", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:397:33
+        { ("SDL_hid_write", "data"), PointerFunctionDataIntent.Unknown }, // /usr/local/include/SDL3/SDL_hidapi.h:311:33
     };
 
     internal static readonly Dictionary<string, ReturnedCharPtrMemoryOwner> ReturnedCharPtrMemoryOwners = new()
@@ -574,35 +611,101 @@ internal static class UserProvidedData
         { "SDL_GetRenderDriver", ReturnedCharPtrMemoryOwner.SDL }, // /usr/local/include/SDL3/SDL_render.h:172:42
         { "SDL_GetRendererName", ReturnedCharPtrMemoryOwner.SDL }, // /usr/local/include/SDL3/SDL_render.h:354:42
         { "SDL_GetRevision", ReturnedCharPtrMemoryOwner.SDL }, // /usr/local/include/SDL3/SDL_version.h:172:42
+        { "SDL_GetGamepadMappings", ReturnedCharPtrMemoryOwner.Unknown }, // /usr/local/include/SDL3/SDL_gamepad.h:423:37
+        { "SDL_GlobDirectory", ReturnedCharPtrMemoryOwner.Unknown }, // /usr/local/include/SDL3/SDL_filesystem.h:448:37
+        { "SDL_GlobStorageDirectory", ReturnedCharPtrMemoryOwner.Unknown }, // /usr/local/include/SDL3/SDL_storage.h:450:37
     };
 
     internal static readonly Dictionary<string, DelegateDefinition> DelegateDefinitions = new()
     {
-        { "SDL_AssertionHandler", new DelegateDefinition { ReturnType = "SDL_AssertState", Parameters = [("SDL_AssertData*", "data"), ("IntPtr", "userdata")] } }, // /usr/local/include/SDL3/SDL_assert.h:423:35
-        { "SDL_CleanupPropertyCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "value")] } }, // /usr/local/include/SDL3/SDL_properties.h:187:24
-        { "SDL_EnumeratePropertiesCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("uint", "props"), ("byte*", "name")] } }, // /usr/local/include/SDL3/SDL_properties.h:499:24
-        { "SDL_ThreadFunction", new DelegateDefinition { ReturnType = "int", Parameters = [("IntPtr", "data")] } }, // /usr/local/include/SDL3/SDL_thread.h:113:24
-        { "SDL_TLSDestructorCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "value")] } }, // /usr/local/include/SDL3/SDL_thread.h:487:24
-        { "SDL_AudioStreamCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "stream"), ("int", "additional_amount"), ("int", "total_amount")] } }, // /usr/local/include/SDL3/SDL_audio.h:1527:24
-        { "SDL_AudioPostmixCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("SDL_AudioSpec*", "spec"), ("float*", "buffer"), ("int", "buflen")] } }, // /usr/local/include/SDL3/SDL_audio.h:1744:24
-        { "SDL_ClipboardDataCallback", new DelegateDefinition { ReturnType = "IntPtr", Parameters = [("IntPtr", "userdata"), ("byte*", "mime_type"), ("IntPtr", "size")] } }, // /usr/local/include/SDL3/SDL_clipboard.h:154:31
-        { "SDL_ClipboardCleanupCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata")] } }, // /usr/local/include/SDL3/SDL_clipboard.h:166:24
+        {
+            "SDL_AssertionHandler",
+            new DelegateDefinition { ReturnType = "SDL_AssertState", Parameters = [("SDL_AssertData*", "data"), ("IntPtr", "userdata")] }
+        }, // /usr/local/include/SDL3/SDL_assert.h:423:35
+        {
+            "SDL_CleanupPropertyCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "value")] }
+        }, // /usr/local/include/SDL3/SDL_properties.h:187:24
+        {
+            "SDL_EnumeratePropertiesCallback",
+            new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("uint", "props"), ("byte*", "name")] }
+        }, // /usr/local/include/SDL3/SDL_properties.h:499:24
+        {
+            "SDL_ThreadFunction", new DelegateDefinition { ReturnType = "int", Parameters = [("IntPtr", "data")] }
+        }, // /usr/local/include/SDL3/SDL_thread.h:113:24
+        {
+            "SDL_TLSDestructorCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "value")] }
+        }, // /usr/local/include/SDL3/SDL_thread.h:487:24
+        {
+            "SDL_AudioStreamCallback",
+            new DelegateDefinition
+                { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "stream"), ("int", "additional_amount"), ("int", "total_amount")] }
+        }, // /usr/local/include/SDL3/SDL_audio.h:1527:24
+        {
+            "SDL_AudioPostmixCallback",
+            new DelegateDefinition
+                { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("SDL_AudioSpec*", "spec"), ("float*", "buffer"), ("int", "buflen")] }
+        }, // /usr/local/include/SDL3/SDL_audio.h:1744:24
+        {
+            "SDL_ClipboardDataCallback",
+            new DelegateDefinition { ReturnType = "IntPtr", Parameters = [("IntPtr", "userdata"), ("byte*", "mime_type"), ("IntPtr", "size")] }
+        }, // /usr/local/include/SDL3/SDL_clipboard.h:154:31
+        {
+            "SDL_ClipboardCleanupCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata")] }
+        }, // /usr/local/include/SDL3/SDL_clipboard.h:166:24
         { "SDL_EGLAttribArrayCallback", new DelegateDefinition { ReturnType = "IntPtr", Parameters = [] } }, // /usr/local/include/SDL3/SDL_video.h:246:34
         { "SDL_EGLIntArrayCallback", new DelegateDefinition { ReturnType = "IntPtr", Parameters = [] } }, // /usr/local/include/SDL3/SDL_video.h:247:31
-        { "SDL_HitTest", new DelegateDefinition { ReturnType = "SDL_HitTestResult", Parameters = [("IntPtr", "win"), ("SDL_Point*", "area"), ("IntPtr", "data")] } }, // /usr/local/include/SDL3/SDL_video.h:2328:37
-        { "SDL_DialogFileCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "filelist"), ("int", "filter")] } }, // /usr/local/include/SDL3/SDL_dialog.h:97:24
-        { "SDL_EventFilter", new DelegateDefinition { ReturnType = "bool", Parameters = [("IntPtr", "userdata"), ("SDL_Event*", "evt")] } }, // /usr/local/include/SDL3/SDL_events.h:1283:24
-        { "SDL_EnumerateDirectoryCallback", new DelegateDefinition { ReturnType = "SDL_EnumerationResult", Parameters = [("IntPtr", "userdata"), ("byte*", "dirname"), ("byte*", "fname")] } }, // /usr/local/include/SDL3/SDL_filesystem.h:302:41
-        { "SDL_HintCallback", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("byte*", "name"), ("byte*", "oldValue"), ("byte*", "newValue")] } }, // /usr/local/include/SDL3/SDL_hints.h:4189:23
-        { "SDL_AppInit_func", new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate"), ("int", "argc"), ("IntPtr", "argv")] } }, // /usr/local/include/SDL3/SDL_init.h:96:33
-        { "SDL_AppIterate_func", new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate")] } }, // /usr/local/include/SDL3/SDL_init.h:97:33
-        { "SDL_AppEvent_func", new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate"), ("SDL_Event*", "evt")] } }, // /usr/local/include/SDL3/SDL_init.h:98:33
-        { "SDL_AppQuit_func", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "appstate"), ("SDL_AppResult", "result")] } }, // /usr/local/include/SDL3/SDL_init.h:99:24
-        { "SDL_LogOutputFunction", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("int", "category"), ("SDL_LogPriority", "priority"), ("byte*", "message")] } }, // /usr/local/include/SDL3/SDL_log.h:474:24
-        { "SDL_X11EventHook", new DelegateDefinition { ReturnType = "bool", Parameters = [("IntPtr", "userdata"), ("IntPtr", "xevent")] } }, // /usr/local/include/SDL3/SDL_system.h:133:24
-        { "SDL_TimerCallback", new DelegateDefinition { ReturnType = "uint", Parameters = [("IntPtr", "userdata"), ("uint", "timerID"), ("uint", "interval")] } }, // /usr/local/include/SDL3/SDL_timer.h:158:26
-        { "SDL_NSTimerCallback", new DelegateDefinition { ReturnType = "ulong", Parameters = [("IntPtr", "userdata"), ("uint", "timerID"), ("ulong", "interval")] } }, // /usr/local/include/SDL3/SDL_timer.h:220:26
-        { "SDL_main_func", new DelegateDefinition { ReturnType = "int", Parameters = [("int", "argc"), ("IntPtr", "argv")] } }, // /usr/local/include/SDL3/SDL_main.h:399:23
+        {
+            "SDL_HitTest",
+            new DelegateDefinition { ReturnType = "SDL_HitTestResult", Parameters = [("IntPtr", "win"), ("SDL_Point*", "area"), ("IntPtr", "data")] }
+        }, // /usr/local/include/SDL3/SDL_video.h:2328:37
+        {
+            "SDL_DialogFileCallback",
+            new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("IntPtr", "filelist"), ("int", "filter")] }
+        }, // /usr/local/include/SDL3/SDL_dialog.h:97:24
+        {
+            "SDL_EventFilter", new DelegateDefinition { ReturnType = "bool", Parameters = [("IntPtr", "userdata"), ("SDL_Event*", "evt")] }
+        }, // /usr/local/include/SDL3/SDL_events.h:1283:24
+        {
+            "SDL_EnumerateDirectoryCallback",
+            new DelegateDefinition { ReturnType = "SDL_EnumerationResult", Parameters = [("IntPtr", "userdata"), ("byte*", "dirname"), ("byte*", "fname")] }
+        }, // /usr/local/include/SDL3/SDL_filesystem.h:302:41
+        {
+            "SDL_HintCallback",
+            new DelegateDefinition
+                { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("byte*", "name"), ("byte*", "oldValue"), ("byte*", "newValue")] }
+        }, // /usr/local/include/SDL3/SDL_hints.h:4189:23
+        {
+            "SDL_AppInit_func",
+            new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate"), ("int", "argc"), ("IntPtr", "argv")] }
+        }, // /usr/local/include/SDL3/SDL_init.h:96:33
+        {
+            "SDL_AppIterate_func", new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate")] }
+        }, // /usr/local/include/SDL3/SDL_init.h:97:33
+        {
+            "SDL_AppEvent_func", new DelegateDefinition { ReturnType = "SDL_AppResult", Parameters = [("IntPtr", "appstate"), ("SDL_Event*", "evt")] }
+        }, // /usr/local/include/SDL3/SDL_init.h:98:33
+        {
+            "SDL_AppQuit_func", new DelegateDefinition { ReturnType = "void", Parameters = [("IntPtr", "appstate"), ("SDL_AppResult", "result")] }
+        }, // /usr/local/include/SDL3/SDL_init.h:99:24
+        {
+            "SDL_LogOutputFunction",
+            new DelegateDefinition
+                { ReturnType = "void", Parameters = [("IntPtr", "userdata"), ("int", "category"), ("SDL_LogPriority", "priority"), ("byte*", "message")] }
+        }, // /usr/local/include/SDL3/SDL_log.h:474:24
+        {
+            "SDL_X11EventHook", new DelegateDefinition { ReturnType = "bool", Parameters = [("IntPtr", "userdata"), ("IntPtr", "xevent")] }
+        }, // /usr/local/include/SDL3/SDL_system.h:133:24
+        {
+            "SDL_TimerCallback",
+            new DelegateDefinition { ReturnType = "uint", Parameters = [("IntPtr", "userdata"), ("uint", "timerID"), ("uint", "interval")] }
+        }, // /usr/local/include/SDL3/SDL_timer.h:158:26
+        {
+            "SDL_NSTimerCallback",
+            new DelegateDefinition { ReturnType = "ulong", Parameters = [("IntPtr", "userdata"), ("uint", "timerID"), ("ulong", "interval")] }
+        }, // /usr/local/include/SDL3/SDL_timer.h:220:26
+        {
+            "SDL_main_func", new DelegateDefinition { ReturnType = "int", Parameters = [("int", "argc"), ("IntPtr", "argv")] }
+        }, // /usr/local/include/SDL3/SDL_main.h:399:23
     };
 
     internal static readonly Dictionary<string, string[]> FlagEnumDefinitions = new()

--- a/GenerateBindings/UserProvidedData.cs
+++ b/GenerateBindings/UserProvidedData.cs
@@ -616,6 +616,21 @@ internal static class UserProvidedData
         { "SDL_GlobStorageDirectory", ReturnedCharPtrMemoryOwner.Unknown }, // /usr/local/include/SDL3/SDL_storage.h:450:37
     };
 
+    internal static readonly Dictionary<string, string> ReturnedArrayCountParamNames = new()
+    {
+        { "SDL_GetAudioDeviceChannelMap", "count" },
+        { "SDL_GetAudioStreamInputChannelMap", "count" }, // /usr/local/include/SDL3/SDL_audio.h:1136:35
+        { "SDL_GetAudioStreamOutputChannelMap", "count" }, // /usr/local/include/SDL3/SDL_audio.h:1160:35
+        { "SDL_GetSurfaceImages", "count" }, // /usr/local/include/SDL3/SDL_surface.h:388:44
+        { "SDL_GetCameraSupportedFormats", "count" }, // /usr/local/include/SDL3/SDL_camera.h:222:47
+        { "SDL_GetFullscreenDisplayModes", "count" }, // /usr/local/include/SDL3/SDL_video.h:649:48
+        { "SDL_GetWindows", "count" }, // /usr/local/include/SDL3/SDL_video.h:885:43
+        { "SDL_GetGamepadBindings", "count" }, // /usr/local/include/SDL3/SDL_gamepad.h:1031:51
+        { "SDL_GetKeyboardState", "numkeys" }, // /usr/local/include/SDL3/SDL_keyboard.h:144:42
+        { "SDL_GetTouchFingers", "count" }, // /usr/local/include/SDL3/SDL_touch.h:129:43
+        { "SDL_GetPreferredLocales", "count" }, // /usr/local/include/SDL3/SDL_locale.h:101:43
+    };
+
     internal static readonly Dictionary<string, DelegateDefinition> DelegateDefinitions = new()
     {
         {

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -122,15 +122,15 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetDefaultAssertionHandler();
+	public static partial SDL_AssertionHandler SDL_GetDefaultAssertionHandler();
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetAssertionHandler(out IntPtr puserdata);
+	public static partial SDL_AssertionHandler SDL_GetAssertionHandler(out IntPtr puserdata);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetAssertionReport();
+	public static partial SDL_AssertData* SDL_GetAssertionReport();
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1330,11 +1330,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetPixelFormatDetails(SDL_PixelFormat format);
+	public static partial SDL_PixelFormatDetails* SDL_GetPixelFormatDetails(SDL_PixelFormat format);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreatePalette(int ncolors);
+	public static partial SDL_Palette* SDL_CreatePalette(int ncolors);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1477,11 +1477,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateSurface(int width, int height, SDL_PixelFormat format);
+	public static partial SDL_Surface* SDL_CreateSurface(int width, int height, SDL_PixelFormat format);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateSurfaceFrom(int width, int height, SDL_PixelFormat format, IntPtr pixels, int pitch);
+	public static partial SDL_Surface* SDL_CreateSurfaceFrom(int width, int height, SDL_PixelFormat format, IntPtr pixels, int pitch);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1501,7 +1501,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateSurfacePalette(IntPtr surface);
+	public static partial SDL_Palette* SDL_CreateSurfacePalette(IntPtr surface);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1509,7 +1509,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetSurfacePalette(IntPtr surface);
+	public static partial SDL_Palette* SDL_GetSurfacePalette(IntPtr surface);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1537,11 +1537,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_LoadBMP_IO(IntPtr src, SDLBool closeio);
+	public static partial SDL_Surface* SDL_LoadBMP_IO(IntPtr src, SDLBool closeio);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_LoadBMP(string file);
+	public static partial SDL_Surface* SDL_LoadBMP(string file);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1609,19 +1609,19 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_DuplicateSurface(IntPtr surface);
+	public static partial SDL_Surface* SDL_DuplicateSurface(IntPtr surface);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_ScaleSurface(IntPtr surface, int width, int height, SDL_ScaleMode scaleMode);
+	public static partial SDL_Surface* SDL_ScaleSurface(IntPtr surface, int width, int height, SDL_ScaleMode scaleMode);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_ConvertSurface(IntPtr surface, SDL_PixelFormat format);
+	public static partial SDL_Surface* SDL_ConvertSurface(IntPtr surface, SDL_PixelFormat format);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_ConvertSurfaceAndColorspace(IntPtr surface, SDL_PixelFormat format, IntPtr palette, SDL_Colorspace colorspace, uint props);
+	public static partial SDL_Surface* SDL_ConvertSurfaceAndColorspace(IntPtr surface, SDL_PixelFormat format, IntPtr palette, SDL_Colorspace colorspace, uint props);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1776,7 +1776,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_AcquireCameraFrame(IntPtr camera, out ulong timestampNS);
+	public static partial SDL_Surface* SDL_AcquireCameraFrame(IntPtr camera, out ulong timestampNS);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2158,11 +2158,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetDesktopDisplayMode(uint displayID);
+	public static partial SDL_DisplayMode* SDL_GetDesktopDisplayMode(uint displayID);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetCurrentDisplayMode(uint displayID);
+	public static partial SDL_DisplayMode* SDL_GetCurrentDisplayMode(uint displayID);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2190,7 +2190,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetWindowFullscreenMode(IntPtr window);
+	public static partial SDL_DisplayMode* SDL_GetWindowFullscreenMode(IntPtr window);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2351,7 +2351,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetWindowSurface(IntPtr window);
+	public static partial SDL_Surface* SDL_GetWindowSurface(IntPtr window);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2399,7 +2399,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetWindowMouseRect(IntPtr window);
+	public static partial SDL_Rect* SDL_GetWindowMouseRect(IntPtr window);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2668,7 +2668,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetSensorData(IntPtr sensor, Span<float> data, int num_values);
+	public static partial SDLBool SDL_GetSensorData(IntPtr sensor, float* data, int num_values);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2850,7 +2850,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SendJoystickVirtualSensorData(IntPtr joystick, SDL_SensorType type, ulong sensor_timestamp, Span<float> data, int num_values);
+	public static partial SDLBool SDL_SendJoystickVirtualSensorData(IntPtr joystick, SDL_SensorType type, ulong sensor_timestamp, float* data, int num_values);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -3389,7 +3389,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetGamepadSensorData(IntPtr gamepad, SDL_SensorType type, Span<float> data, int num_values);
+	public static partial SDLBool SDL_GetGamepadSensorData(IntPtr gamepad, SDL_SensorType type, float* data, int num_values);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6552,7 +6552,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_hid_enumerate(ushort vendor_id, ushort product_id);
+	public static partial SDL_hid_device_info* SDL_hid_enumerate(ushort vendor_id, ushort product_id);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6616,7 +6616,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_hid_get_device_info(IntPtr dev);
+	public static partial SDL_hid_device_info* SDL_hid_get_device_info(IntPtr dev);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7104,7 +7104,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetDefaultLogOutputFunction();
+	public static partial SDL_LogOutputFunction SDL_GetDefaultLogOutputFunction();
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7449,15 +7449,15 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateTexture(IntPtr renderer, SDL_PixelFormat format, SDL_TextureAccess access, int w, int h);
+	public static partial SDL_Texture* SDL_CreateTexture(IntPtr renderer, SDL_PixelFormat format, SDL_TextureAccess access, int w, int h);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateTextureFromSurface(IntPtr renderer, IntPtr surface);
+	public static partial SDL_Texture* SDL_CreateTextureFromSurface(IntPtr renderer, IntPtr surface);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_CreateTextureWithProperties(IntPtr renderer, uint props);
+	public static partial SDL_Texture* SDL_CreateTextureWithProperties(IntPtr renderer, uint props);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7549,7 +7549,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetRenderTarget(IntPtr renderer);
+	public static partial SDL_Texture* SDL_GetRenderTarget(IntPtr renderer);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7705,7 +7705,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_RenderReadPixels(IntPtr renderer, ref SDL_Rect rect);
+	public static partial SDL_Surface* SDL_RenderReadPixels(IntPtr renderer, ref SDL_Rect rect);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -809,7 +809,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetAudioDeviceChannelMap(uint devid, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<int> SDL_GetAudioDeviceChannelMap(uint devid, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -893,11 +894,13 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetAudioStreamInputChannelMap(IntPtr stream, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<int> SDL_GetAudioStreamInputChannelMap(IntPtr stream, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetAudioStreamOutputChannelMap(IntPtr stream, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<int> SDL_GetAudioStreamOutputChannelMap(IntPtr stream, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1521,7 +1524,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetSurfaceImages(IntPtr surface, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetSurfaceImages(IntPtr surface, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1743,7 +1747,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetCameraSupportedFormats(uint devid, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetCameraSupportedFormats(uint devid, out int count);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2150,7 +2155,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetFullscreenDisplayModes(uint displayID, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetFullscreenDisplayModes(uint displayID, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2202,7 +2208,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetWindows(out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetWindows(out int count);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -3302,7 +3309,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetGamepadBindings(IntPtr gamepad, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetGamepadBindings(IntPtr gamepad, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -3981,7 +3989,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetKeyboardState(out int numkeys);
+	[return: MarshalUsing(CountElementName = "numkeys")]
+	public static partial Span<SDLBool> SDL_GetKeyboardState(out int numkeys);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -4274,7 +4283,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetTouchFingers(ulong touchID, out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetTouchFingers(ulong touchID, out int count);
 
 	// /usr/local/include/SDL3/SDL_events.h
 
@@ -7002,7 +7012,8 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_GetPreferredLocales(out int count);
+	[return: MarshalUsing(CountElementName = "count")]
+	public static partial Span<IntPtr> SDL_GetPreferredLocales(out int count);
 
 	// /usr/local/include/SDL3/SDL_log.h
 


### PR DESCRIPTION
partially resolves #9

this PR introduces an update to the generator that attempts to specify function return types where possible, rather than always returning IntPtrs when the return value is a pointer. this is a disruptive change that alters lots of existing function signatures, and i believe it will blow up existing `Marshal.PtrToStructure` calls, so i'm not sure how we'd like to handle the rollout here.

this change does not attempt to marshal returned c-style arrays since it seems some additional attribute config is necessary (`SizeParamIndex` to inform the marshaller of the length of the array, i believe) -- i'll handle that in a future PR.