### PR TITLE
Fix Span returns in Core mode

### DIFF
--- a/GenerateBindings/Program.cs
+++ b/GenerateBindings/Program.cs
@@ -488,7 +488,15 @@ internal static partial class Program
                                         typeName = $"out {subtypeName}";
                                         break;
                                     case UserProvidedData.PointerFunctionDataIntent.Array:
-                                        typeName = CoreMode ? "IntPtr" : $"{subtypeName}[]";
+                                        if (CoreMode) {
+                                            if (isReturn) {
+                                                typeName = "IntPtr";
+                                            } else {
+                                                typeName = $"Span<{subtypeName}>";
+                                            }
+                                        } else {
+                                            typeName = $"{subtypeName}[]";
+                                        }
                                         break;
                                     case UserProvidedData.PointerFunctionDataIntent.OutArray:
                                         typeName = CoreMode ? $"Span<{subtypeName}>" : $"[Out] {subtypeName}[]";

--- a/GenerateBindings/Program.cs
+++ b/GenerateBindings/Program.cs
@@ -488,7 +488,7 @@ internal static partial class Program
                                         typeName = $"out {subtypeName}";
                                         break;
                                     case UserProvidedData.PointerFunctionDataIntent.Array:
-                                        typeName = CoreMode ? $"Span<{subtypeName}>" : $"{subtypeName}[]";
+                                        typeName = CoreMode ? "IntPtr" : $"{subtypeName}[]";
                                         break;
                                     case UserProvidedData.PointerFunctionDataIntent.OutArray:
                                         typeName = CoreMode ? $"Span<{subtypeName}>" : $"[Out] {subtypeName}[]";
@@ -690,6 +690,60 @@ internal static partial class Program
                 {
                     if (CoreMode)
                     {
+                        // Handle array -> span marshalling by generating a helper function
+                        if (FunctionSignature.ReturnIntent == FunctionSignatureType.ReturnIntentType.Array)
+                        {
+                            if (UserProvidedData.ReturnedArrayCountParamNames.TryGetValue(FunctionSignature.Name, value: out var countParamName))
+                            {
+                                UnusedUserProvidedTypes.Remove(FunctionSignature.Name);
+
+                                var stringList = new List<string>();
+                                foreach (var (typeName, name) in FunctionSignature.ParameterTypesNames)
+                                {
+                                    if (countParamName != name) {
+                                        stringList.Add($"{typeName} {name}");
+                                    }
+                                }
+                                var signatureArgs = $"({string.Join(", ", stringList)})";
+
+                                stringList.Clear();
+                                foreach (var (typeName, name) in FunctionSignature.ParameterTypesNames)
+                                {
+                                    if (countParamName != name) {
+                                        stringList.Add($"{name}");
+                                    } else {
+                                        stringList.Add($"out var {name}");
+                                    }
+                                }
+                                var arguments = $"({string.Join(", ", stringList)})";
+
+                                stringList.Clear();
+                                foreach (var (typeName, name) in FunctionSignature.ParameterTypesNames)
+                                {
+                                    if (countParamName != name) {
+                                        stringList.Add($"{name}");
+                                    }
+                                }
+                                var argumentsWithoutCount = string.Join(", ", stringList);
+
+                                var componentType = entry.ReturnType!;
+                                var subtype = GetTypeFromTypedefMap(type: componentType.Type!);
+                                var subtypeName = CSharpTypeFromFFI(subtype, TypeContext.FunctionData);
+
+                                definitions.Append($"public static Span<{subtypeName}> {FunctionSignature.Name}{signatureArgs}\n");
+                                definitions.Append("{\n");
+                                definitions.Append($"var result = {FunctionSignature.Name}{arguments};\n");
+                                definitions.Append($"return new Span<{subtypeName}>(result, {countParamName});\n");
+                                definitions.Append("}\n\n");
+                            }
+                            else
+                            {
+                                unknownReturnedArrayCountParamNames.Append(
+                                    $"{{ \"{FunctionSignature.Name!}\", \"WARN_MISSING_COUNT_PARAM_NAME\" }}, // {entry.Header}\n"
+                                );
+                            }
+                        }
+
                         if (FunctionSignature.RequiresStringMarshalling)
                         {
                             definitions.Append("[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]");
@@ -701,24 +755,8 @@ internal static partial class Program
 
                         definitions.Append($"[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]\n");
 
-                        // Handle array marshalling
-                        if (FunctionSignature.ReturnIntent == FunctionSignatureType.ReturnIntentType.Array)
-                        {
-                            if (UserProvidedData.ReturnedArrayCountParamNames.TryGetValue(FunctionSignature.Name, value: out var countParamName))
-                            {
-                                UnusedUserProvidedTypes.Remove(FunctionSignature.Name);
-                                definitions.Append($"[return: MarshalUsing(CountElementName = \"{countParamName}\")]\n");
-                            }
-                            else
-                            {
-                                unknownReturnedArrayCountParamNames.Append(
-                                    $"{{ \"{FunctionSignature.Name!}\", \"WARN_MISSING_COUNT_PARAM_NAME\" }}, // {entry.Header}\n"
-                                );
-                            }
-                        }
-
                         // Handle string marshalling
-                        else if (FunctionSignature.ReturnIntent == FunctionSignatureType.ReturnIntentType.String)
+                        if (FunctionSignature.ReturnIntent == FunctionSignatureType.ReturnIntentType.String)
                         {
                             if (UserProvidedData.ReturnedCharPtrMemoryOwners.TryGetValue(FunctionSignature.Name, value: out var memoryOwner))
                             {

--- a/GenerateBindings/Program.cs
+++ b/GenerateBindings/Program.cs
@@ -741,7 +741,7 @@ internal static partial class Program
                                 definitions.Append($"public static Span<{subtypeName}> {FunctionSignature.Name}{signatureArgs}\n");
                                 definitions.Append("{\n");
                                 definitions.Append($"var result = {FunctionSignature.Name}{arguments};\n");
-                                definitions.Append($"return new Span<{subtypeName}>(result, {countParamName});\n");
+                                definitions.Append($"return new Span<{subtypeName}>((void*) result, {countParamName});\n");
                                 definitions.Append("}\n\n");
                             }
                             else

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -903,7 +903,7 @@ public static unsafe partial class SDL
 	public static Span<int> SDL_GetAudioDeviceChannelMap(uint devid)
 	{
 		var result = SDL_GetAudioDeviceChannelMap(devid, out var count);
-		return new Span<int>(result, count);
+		return new Span<int>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -1001,7 +1001,7 @@ public static unsafe partial class SDL
 	public static Span<int> SDL_GetAudioStreamInputChannelMap(IntPtr stream)
 	{
 		var result = SDL_GetAudioStreamInputChannelMap(stream, out var count);
-		return new Span<int>(result, count);
+		return new Span<int>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -1011,7 +1011,7 @@ public static unsafe partial class SDL
 	public static Span<int> SDL_GetAudioStreamOutputChannelMap(IntPtr stream)
 	{
 		var result = SDL_GetAudioStreamOutputChannelMap(stream, out var count);
-		return new Span<int>(result, count);
+		return new Span<int>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -1645,7 +1645,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetSurfaceImages(IntPtr surface)
 	{
 		var result = SDL_GetSurfaceImages(surface, out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -1873,7 +1873,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetCameraSupportedFormats(uint devid)
 	{
 		var result = SDL_GetCameraSupportedFormats(devid, out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -2287,7 +2287,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetFullscreenDisplayModes(uint displayID)
 	{
 		var result = SDL_GetFullscreenDisplayModes(displayID, out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -2345,7 +2345,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetWindows()
 	{
 		var result = SDL_GetWindows(out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -3471,7 +3471,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetGamepadBindings(IntPtr gamepad)
 	{
 		var result = SDL_GetGamepadBindings(gamepad, out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -4163,7 +4163,7 @@ public static unsafe partial class SDL
 	public static Span<SDLBool> SDL_GetKeyboardState()
 	{
 		var result = SDL_GetKeyboardState(out var numkeys);
-		return new Span<SDLBool>(result, numkeys);
+		return new Span<SDLBool>((void*) result, numkeys);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -4462,7 +4462,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetTouchFingers(ulong touchID)
 	{
 		var result = SDL_GetTouchFingers(touchID, out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]
@@ -7239,7 +7239,7 @@ public static unsafe partial class SDL
 	public static Span<IntPtr> SDL_GetPreferredLocales()
 	{
 		var result = SDL_GetPreferredLocales(out var count);
-		return new Span<IntPtr>(result, count);
+		return new Span<IntPtr>((void*) result, count);
 	}
 
 	[LibraryImport(nativeLibName)]

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -8303,10 +8303,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial IntPtr SDL_GetTraySubmenu(IntPtr entry);
 
+	public static Span<IntPtr> SDL_GetTrayEntries(IntPtr menu)
+	{
+		var result = SDL_GetTrayEntries(menu, out var size);
+		return new Span<IntPtr>((void*) result, size);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "size")]
-	public static partial Span<IntPtr> SDL_GetTrayEntries(IntPtr menu, out int size);
+	public static partial IntPtr SDL_GetTrayEntries(IntPtr menu, out int size);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -900,10 +900,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_GetAudioDeviceFormat(uint devid, out SDL_AudioSpec spec, out int sample_frames);
 
+	public static Span<int> SDL_GetAudioDeviceChannelMap(uint devid)
+	{
+		var result = SDL_GetAudioDeviceChannelMap(devid, out var count);
+		return new Span<int>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<int> SDL_GetAudioDeviceChannelMap(uint devid, out int count);
+	public static partial IntPtr SDL_GetAudioDeviceChannelMap(uint devid, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -943,7 +948,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_BindAudioStreams(uint devid, Span<IntPtr> streams, int num_streams);
+	public static partial SDLBool SDL_BindAudioStreams(uint devid, IntPtr streams, int num_streams);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -951,7 +956,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_UnbindAudioStreams(Span<IntPtr> streams, int num_streams);
+	public static partial void SDL_UnbindAudioStreams(IntPtr streams, int num_streams);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -993,23 +998,33 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_SetAudioStreamGain(IntPtr stream, float gain);
 
-	[LibraryImport(nativeLibName)]
-	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<int> SDL_GetAudioStreamInputChannelMap(IntPtr stream, out int count);
+	public static Span<int> SDL_GetAudioStreamInputChannelMap(IntPtr stream)
+	{
+		var result = SDL_GetAudioStreamInputChannelMap(stream, out var count);
+		return new Span<int>(result, count);
+	}
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<int> SDL_GetAudioStreamOutputChannelMap(IntPtr stream, out int count);
+	public static partial IntPtr SDL_GetAudioStreamInputChannelMap(IntPtr stream, out int count);
+
+	public static Span<int> SDL_GetAudioStreamOutputChannelMap(IntPtr stream)
+	{
+		var result = SDL_GetAudioStreamOutputChannelMap(stream, out var count);
+		return new Span<int>(result, count);
+	}
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetAudioStreamInputChannelMap(IntPtr stream, Span<int> chmap, int count);
+	public static partial IntPtr SDL_GetAudioStreamOutputChannelMap(IntPtr stream, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetAudioStreamOutputChannelMap(IntPtr stream, Span<int> chmap, int count);
+	public static partial SDLBool SDL_SetAudioStreamInputChannelMap(IntPtr stream, IntPtr chmap, int count);
+
+	[LibraryImport(nativeLibName)]
+	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+	public static partial SDLBool SDL_SetAudioStreamOutputChannelMap(IntPtr stream, IntPtr chmap, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1446,7 +1461,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetPaletteColors(IntPtr palette, Span<SDL_Color> colors, int firstcolor, int ncolors);
+	public static partial SDLBool SDL_SetPaletteColors(IntPtr palette, IntPtr colors, int firstcolor, int ncolors);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1516,7 +1531,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetRectEnclosingPoints(Span<SDL_Point> points, int count, ref SDL_Rect clip, out SDL_Rect result);
+	public static partial SDLBool SDL_GetRectEnclosingPoints(IntPtr points, int count, ref SDL_Rect clip, out SDL_Rect result);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1536,7 +1551,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetRectEnclosingPointsFloat(Span<SDL_FPoint> points, int count, ref SDL_FRect clip, out SDL_FRect result);
+	public static partial SDLBool SDL_GetRectEnclosingPointsFloat(IntPtr points, int count, ref SDL_FRect clip, out SDL_FRect result);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1627,10 +1642,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_SurfaceHasAlternateImages(IntPtr surface);
 
+	public static Span<IntPtr> SDL_GetSurfaceImages(IntPtr surface)
+	{
+		var result = SDL_GetSurfaceImages(surface, out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetSurfaceImages(IntPtr surface, out int count);
+	public static partial IntPtr SDL_GetSurfaceImages(IntPtr surface, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1758,7 +1778,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_FillSurfaceRects(IntPtr dst, Span<SDL_Rect> rects, int count, uint color);
+	public static partial SDLBool SDL_FillSurfaceRects(IntPtr dst, IntPtr rects, int count, uint color);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1850,10 +1870,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial IntPtr SDL_GetCameras(out int count);
 
+	public static Span<IntPtr> SDL_GetCameraSupportedFormats(uint devid)
+	{
+		var result = SDL_GetCameraSupportedFormats(devid, out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetCameraSupportedFormats(uint devid, out int count);
+	public static partial IntPtr SDL_GetCameraSupportedFormats(uint devid, out int count);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2259,10 +2284,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial float SDL_GetDisplayContentScale(uint displayID);
 
+	public static Span<IntPtr> SDL_GetFullscreenDisplayModes(uint displayID)
+	{
+		var result = SDL_GetFullscreenDisplayModes(displayID, out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetFullscreenDisplayModes(uint displayID, out int count);
+	public static partial IntPtr SDL_GetFullscreenDisplayModes(uint displayID, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2312,10 +2342,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDL_PixelFormat SDL_GetWindowPixelFormat(IntPtr window);
 
+	public static Span<IntPtr> SDL_GetWindows()
+	{
+		var result = SDL_GetWindows(out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetWindows(out int count);
+	public static partial IntPtr SDL_GetWindows(out int count);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2480,7 +2515,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_UpdateWindowSurfaceRects(IntPtr window, Span<SDL_Rect> rects, int numrects);
+	public static partial SDLBool SDL_UpdateWindowSurfaceRects(IntPtr window, IntPtr rects, int numrects);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2686,11 +2721,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, Span<SDL_DialogFileFilter> filters, int nfilters, string default_location, SDLBool allow_many);
+	public static partial void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, IntPtr filters, int nfilters, string default_location, SDLBool allow_many);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, Span<SDL_DialogFileFilter> filters, int nfilters, string default_location);
+	public static partial void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, IntPtr filters, int nfilters, string default_location);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -3433,10 +3468,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDLBool SDL_GamepadEventsEnabled();
 
+	public static Span<IntPtr> SDL_GetGamepadBindings(IntPtr gamepad)
+	{
+		var result = SDL_GetGamepadBindings(gamepad, out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetGamepadBindings(IntPtr gamepad, out int count);
+	public static partial IntPtr SDL_GetGamepadBindings(IntPtr gamepad, out int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -4120,10 +4160,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial IntPtr SDL_GetKeyboardFocus();
 
+	public static Span<SDLBool> SDL_GetKeyboardState()
+	{
+		var result = SDL_GetKeyboardState(out var numkeys);
+		return new Span<SDLBool>(result, numkeys);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "numkeys")]
-	public static partial Span<SDLBool> SDL_GetKeyboardState(out int numkeys);
+	public static partial IntPtr SDL_GetKeyboardState(out int numkeys);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -4414,10 +4459,15 @@ public static unsafe partial class SDL
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
 	public static partial SDL_TouchDeviceType SDL_GetTouchDeviceType(ulong touchID);
 
+	public static Span<IntPtr> SDL_GetTouchFingers(ulong touchID)
+	{
+		var result = SDL_GetTouchFingers(touchID, out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetTouchFingers(ulong touchID, out int count);
+	public static partial IntPtr SDL_GetTouchFingers(ulong touchID, out int count);
 
 	// /usr/local/include/SDL3/SDL_events.h
 
@@ -6190,7 +6240,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_BeginGPURenderPass(IntPtr command_buffer, Span<SDL_GPUColorTargetInfo> color_target_infos, uint num_color_targets, in SDL_GPUDepthStencilTargetInfo depth_stencil_target_info);
+	public static partial IntPtr SDL_BeginGPURenderPass(IntPtr command_buffer, IntPtr color_target_infos, uint num_color_targets, in SDL_GPUDepthStencilTargetInfo depth_stencil_target_info);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6214,7 +6264,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexBuffers(IntPtr render_pass, uint first_slot, Span<SDL_GPUBufferBinding> bindings, uint num_bindings);
+	public static partial void SDL_BindGPUVertexBuffers(IntPtr render_pass, uint first_slot, IntPtr bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6222,27 +6272,27 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexSamplers(IntPtr render_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUVertexSamplers(IntPtr render_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexStorageTextures(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUVertexStorageTextures(IntPtr render_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexStorageBuffers(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUVertexStorageBuffers(IntPtr render_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentSamplers(IntPtr render_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentSamplers(IntPtr render_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentStorageTextures(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentStorageTextures(IntPtr render_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentStorageBuffers(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentStorageBuffers(IntPtr render_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6266,7 +6316,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_BeginGPUComputePass(IntPtr command_buffer, Span<SDL_GPUStorageTextureReadWriteBinding> storage_texture_bindings, uint num_storage_texture_bindings, Span<SDL_GPUStorageBufferReadWriteBinding> storage_buffer_bindings, uint num_storage_buffer_bindings);
+	public static partial IntPtr SDL_BeginGPUComputePass(IntPtr command_buffer, IntPtr storage_texture_bindings, uint num_storage_texture_bindings, IntPtr storage_buffer_bindings, uint num_storage_buffer_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6274,15 +6324,15 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeSamplers(IntPtr compute_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUComputeSamplers(IntPtr compute_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeStorageTextures(IntPtr compute_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUComputeStorageTextures(IntPtr compute_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeStorageBuffers(IntPtr compute_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUComputeStorageBuffers(IntPtr compute_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6402,7 +6452,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_WaitForGPUFences(IntPtr device, SDLBool wait_all, Span<IntPtr> fences, uint num_fences);
+	public static partial SDLBool SDL_WaitForGPUFences(IntPtr device, SDLBool wait_all, IntPtr fences, uint num_fences);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7186,10 +7236,15 @@ public static unsafe partial class SDL
 		public byte* country;
 	}
 
+	public static Span<IntPtr> SDL_GetPreferredLocales()
+	{
+		var result = SDL_GetPreferredLocales(out var count);
+		return new Span<IntPtr>(result, count);
+	}
+
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	[return: MarshalUsing(CountElementName = "count")]
-	public static partial Span<IntPtr> SDL_GetPreferredLocales(out int count);
+	public static partial IntPtr SDL_GetPreferredLocales(out int count);
 
 	// /usr/local/include/SDL3/SDL_log.h
 
@@ -7841,7 +7896,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderPoints(IntPtr renderer, Span<SDL_FPoint> points, int count);
+	public static partial SDLBool SDL_RenderPoints(IntPtr renderer, IntPtr points, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7849,7 +7904,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderLines(IntPtr renderer, Span<SDL_FPoint> points, int count);
+	public static partial SDLBool SDL_RenderLines(IntPtr renderer, IntPtr points, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7857,7 +7912,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderRects(IntPtr renderer, Span<SDL_FRect> rects, int count);
+	public static partial SDLBool SDL_RenderRects(IntPtr renderer, IntPtr rects, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7865,7 +7920,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderFillRects(IntPtr renderer, Span<SDL_FRect> rects, int count);
+	public static partial SDLBool SDL_RenderFillRects(IntPtr renderer, IntPtr rects, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7889,7 +7944,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderGeometry(IntPtr renderer, IntPtr texture, Span<SDL_Vertex> vertices, int num_vertices, Span<int> indices, int num_indices); // WARN_UNKNOWN_POINTER_PARAMETER
+	public static partial SDLBool SDL_RenderGeometry(IntPtr renderer, IntPtr texture, IntPtr vertices, int num_vertices, IntPtr indices, int num_indices); // WARN_UNKNOWN_POINTER_PARAMETER
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3/SDL3.Core.cs
+++ b/SDL3/SDL3.Core.cs
@@ -948,7 +948,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_BindAudioStreams(uint devid, IntPtr streams, int num_streams);
+	public static partial SDLBool SDL_BindAudioStreams(uint devid, Span<IntPtr> streams, int num_streams);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -956,7 +956,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_UnbindAudioStreams(IntPtr streams, int num_streams);
+	public static partial void SDL_UnbindAudioStreams(Span<IntPtr> streams, int num_streams);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1020,11 +1020,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetAudioStreamInputChannelMap(IntPtr stream, IntPtr chmap, int count);
+	public static partial SDLBool SDL_SetAudioStreamInputChannelMap(IntPtr stream, Span<int> chmap, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetAudioStreamOutputChannelMap(IntPtr stream, IntPtr chmap, int count);
+	public static partial SDLBool SDL_SetAudioStreamOutputChannelMap(IntPtr stream, Span<int> chmap, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1461,7 +1461,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_SetPaletteColors(IntPtr palette, IntPtr colors, int firstcolor, int ncolors);
+	public static partial SDLBool SDL_SetPaletteColors(IntPtr palette, Span<SDL_Color> colors, int firstcolor, int ncolors);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1531,7 +1531,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetRectEnclosingPoints(IntPtr points, int count, ref SDL_Rect clip, out SDL_Rect result);
+	public static partial SDLBool SDL_GetRectEnclosingPoints(Span<SDL_Point> points, int count, ref SDL_Rect clip, out SDL_Rect result);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1551,7 +1551,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_GetRectEnclosingPointsFloat(IntPtr points, int count, ref SDL_FRect clip, out SDL_FRect result);
+	public static partial SDLBool SDL_GetRectEnclosingPointsFloat(Span<SDL_FPoint> points, int count, ref SDL_FRect clip, out SDL_FRect result);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -1778,7 +1778,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_FillSurfaceRects(IntPtr dst, IntPtr rects, int count, uint color);
+	public static partial SDLBool SDL_FillSurfaceRects(IntPtr dst, Span<SDL_Rect> rects, int count, uint color);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2515,7 +2515,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_UpdateWindowSurfaceRects(IntPtr window, IntPtr rects, int numrects);
+	public static partial SDLBool SDL_UpdateWindowSurfaceRects(IntPtr window, Span<SDL_Rect> rects, int numrects);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -2721,11 +2721,11 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, IntPtr filters, int nfilters, string default_location, SDLBool allow_many);
+	public static partial void SDL_ShowOpenFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, Span<SDL_DialogFileFilter> filters, int nfilters, string default_location, SDLBool allow_many);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, IntPtr filters, int nfilters, string default_location);
+	public static partial void SDL_ShowSaveFileDialog(SDL_DialogFileCallback callback, IntPtr userdata, IntPtr window, Span<SDL_DialogFileFilter> filters, int nfilters, string default_location);
 
 	[LibraryImport(nativeLibName, StringMarshalling = StringMarshalling.Utf8)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6240,7 +6240,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_BeginGPURenderPass(IntPtr command_buffer, IntPtr color_target_infos, uint num_color_targets, in SDL_GPUDepthStencilTargetInfo depth_stencil_target_info);
+	public static partial IntPtr SDL_BeginGPURenderPass(IntPtr command_buffer, Span<SDL_GPUColorTargetInfo> color_target_infos, uint num_color_targets, in SDL_GPUDepthStencilTargetInfo depth_stencil_target_info);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6264,7 +6264,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexBuffers(IntPtr render_pass, uint first_slot, IntPtr bindings, uint num_bindings);
+	public static partial void SDL_BindGPUVertexBuffers(IntPtr render_pass, uint first_slot, Span<SDL_GPUBufferBinding> bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6272,27 +6272,27 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexSamplers(IntPtr render_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUVertexSamplers(IntPtr render_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexStorageTextures(IntPtr render_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUVertexStorageTextures(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUVertexStorageBuffers(IntPtr render_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUVertexStorageBuffers(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentSamplers(IntPtr render_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentSamplers(IntPtr render_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentStorageTextures(IntPtr render_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentStorageTextures(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUFragmentStorageBuffers(IntPtr render_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUFragmentStorageBuffers(IntPtr render_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6316,7 +6316,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial IntPtr SDL_BeginGPUComputePass(IntPtr command_buffer, IntPtr storage_texture_bindings, uint num_storage_texture_bindings, IntPtr storage_buffer_bindings, uint num_storage_buffer_bindings);
+	public static partial IntPtr SDL_BeginGPUComputePass(IntPtr command_buffer, Span<SDL_GPUStorageTextureReadWriteBinding> storage_texture_bindings, uint num_storage_texture_bindings, Span<SDL_GPUStorageBufferReadWriteBinding> storage_buffer_bindings, uint num_storage_buffer_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6324,15 +6324,15 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeSamplers(IntPtr compute_pass, uint first_slot, IntPtr texture_sampler_bindings, uint num_bindings);
+	public static partial void SDL_BindGPUComputeSamplers(IntPtr compute_pass, uint first_slot, Span<SDL_GPUTextureSamplerBinding> texture_sampler_bindings, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeStorageTextures(IntPtr compute_pass, uint first_slot, IntPtr storage_textures, uint num_bindings);
+	public static partial void SDL_BindGPUComputeStorageTextures(IntPtr compute_pass, uint first_slot, Span<IntPtr> storage_textures, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial void SDL_BindGPUComputeStorageBuffers(IntPtr compute_pass, uint first_slot, IntPtr storage_buffers, uint num_bindings);
+	public static partial void SDL_BindGPUComputeStorageBuffers(IntPtr compute_pass, uint first_slot, Span<IntPtr> storage_buffers, uint num_bindings);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -6452,7 +6452,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_WaitForGPUFences(IntPtr device, SDLBool wait_all, IntPtr fences, uint num_fences);
+	public static partial SDLBool SDL_WaitForGPUFences(IntPtr device, SDLBool wait_all, Span<IntPtr> fences, uint num_fences);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7896,7 +7896,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderPoints(IntPtr renderer, IntPtr points, int count);
+	public static partial SDLBool SDL_RenderPoints(IntPtr renderer, Span<SDL_FPoint> points, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7904,7 +7904,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderLines(IntPtr renderer, IntPtr points, int count);
+	public static partial SDLBool SDL_RenderLines(IntPtr renderer, Span<SDL_FPoint> points, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7912,7 +7912,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderRects(IntPtr renderer, IntPtr rects, int count);
+	public static partial SDLBool SDL_RenderRects(IntPtr renderer, Span<SDL_FRect> rects, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7920,7 +7920,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderFillRects(IntPtr renderer, IntPtr rects, int count);
+	public static partial SDLBool SDL_RenderFillRects(IntPtr renderer, Span<SDL_FRect> rects, int count);
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
@@ -7944,7 +7944,7 @@ public static unsafe partial class SDL
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-	public static partial SDLBool SDL_RenderGeometry(IntPtr renderer, IntPtr texture, IntPtr vertices, int num_vertices, IntPtr indices, int num_indices); // WARN_UNKNOWN_POINTER_PARAMETER
+	public static partial SDLBool SDL_RenderGeometry(IntPtr renderer, IntPtr texture, Span<SDL_Vertex> vertices, int num_vertices, Span<int> indices, int num_indices); // WARN_UNKNOWN_POINTER_PARAMETER
 
 	[LibraryImport(nativeLibName)]
 	[UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]

--- a/SDL3/SDL3.Legacy.cs
+++ b/SDL3/SDL3.Legacy.cs
@@ -8419,9 +8419,6 @@ namespace SDL3
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_EnterAppMainCallbacks(int argc, IntPtr argv, SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit);
 
-		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-		public static extern void SDL_GDKSuspendComplete();
-
 
 	}
 }

--- a/SDL3/SDL3.Legacy.cs
+++ b/SDL3/SDL3.Legacy.cs
@@ -8419,6 +8419,9 @@ namespace SDL3
 		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 		public static extern int SDL_EnterAppMainCallbacks(int argc, IntPtr argv, SDL_AppInit_func appinit, SDL_AppIterate_func appiter, SDL_AppEvent_func appevent, SDL_AppQuit_func appquit);
 
+		[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+		public static extern void SDL_GDKSuspendComplete();
+
 
 	}
 }


### PR DESCRIPTION
We can't actually return spans from P/Invoke but it's nice to have spans, so this PR does some method generation to create an overload that returns a Span. 

Note that I haven't had the chance to actually test this so someone should probably do that. 

Fixes #30 