### PR TITLE
Automated ffi file

### DIFF
--- a/generate_json.sh
+++ b/generate_json.sh
@@ -1,0 +1,18 @@
+#!env sh
+if [ ! -z $1 ]; then
+    c2ffi_executable=$1
+elif ! command -v c2ffi 2>&1 >/dev/null; then
+    echo "c2ffi could not be found in PATH"
+    exit 1
+else
+    c2ffi_executable="c2ffi"
+fi
+
+cat > tmp.c <<- EOM
+#include <SDL3/SDL.h>
+#include <SDL3/SDL_main.h>
+#include <SDL3/SDL_vulkan.h>
+EOM
+
+$c2ffi_executable tmp.c -o GenerateBindings/assets/ffi.json
+rm tmp.c


### PR DESCRIPTION
Hello, I am creating a PR as a draft because I changed a bunch of stuff but I will explain why I did the changes and alternatives. I am fine with changing anything and separating things into different PRs, I am just making this chunk more to discuss things than to actually get things merged.

At first I was going to just make a bash file, but then I changed my mind because then we would need to create a script file for windows too, and that's kinda annoying to maintain.

Anyway, the script is there if you prefer to just use it instead. It doesn't support automatically gathering the include files automatic tho.

And I have an aversion to create multiple codes that does the same thing. Since we have a script that creates bindings in C# I thought I might as well create a C# script too.

I also want to make the bindings automatically generated via CI after the automatic creation of the json file gets finished in the next PR.

This PR is also not complete because I plan to modify `GenerateBindings` to support command arguments where you can define the location of the bindings and where the json is. But I wanted to start a discussion first before doing it.

Oh, and I also will make the instructions in how to use everything.

## Main objective of this PR
Generate a ffi.json in the current working directory automatically. For that the user executes the command:
```
JsonGenerator Path/To/SDL/include/ Path/To/c2ffi
```
If you don't specify the path to c2ffi it will attempt to look it up in the `PATH`

Expansion plans include checking for the SDL/include in the `INCLUDE` if the argument was not specified and yell at the user.

`JsonGenerator` also automatically detect header files that are not in `SDL3/SDL.h` header and automatically adds them to the `tmp.c` where `c2ffi` runs

## Why the scripts folder and new solution file
I created the scripts folder because the generators are not exactly part of the bindings so in my brain at least it makes sense for them to be separated.

I also create a new dll with shared code between `GenerateBindings` and `JsonGenerator` because I have an aversion to copy pasting code.

Alternatives would be:
* Merging `JsonGenerator` into `GenerateBindings` and either make things step by step with command arguments or fully automated. I didn't do it because it might be useful keeping things separated.
* Separate things further and create a `GenerateHeader` that just creates the `tmp.c` with the headers. Might be useful later on.